### PR TITLE
Fix redirections for old Win32 reference content

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1,0 +1,1474 @@
+{
+  "redirections": [
+    {
+      "source_path": "non-version/0-8-190-reference-webview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430-reference-webview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488-reference-webview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538-reference-webview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622-reference-webview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/webview2-idl.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/webview2-idl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/webview2-idl.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/webview2-idl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/webview2-idl.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/webview2-idl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/webview2-idl.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/webview2-idl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/webview2-idl.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/webview2-idl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2acceleratorkeypressedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2acceleratorkeypressedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2acceleratorkeypressedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2acceleratorkeypressedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2addscripttoexecuteondocumentcreatedcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2addscripttoexecuteondocumentcreatedcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2calldevtoolsprotocolmethodcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2calldevtoolsprotocolmethodcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2capturepreviewcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2capturepreviewcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2containsfullscreenelementchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2containsfullscreenelementchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2createwebview2environmentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2createwebview2environmentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2createwebviewcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2createwebviewcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2deferral.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2deferral",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2devtoolsprotocoleventreceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2devtoolsprotocoleventreceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2devtoolsprotocoleventreceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2devtoolsprotocoleventreceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2documentstatechangedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2documentstatechangedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2documentstatechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2documentstatechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2documenttitlechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2documenttitlechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2environment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2environment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2environment2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2environment2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2environment3.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2environment3",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2executescriptcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2executescriptcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2focuschangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2focuschangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2httpheaderscollectioniterator.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2httpheaderscollectioniterator",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2httprequestheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2httprequestheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2httpresponseheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2httpresponseheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2movefocusrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2movefocusrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2movefocusrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2movefocusrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2navigationcompletedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2navigationcompletedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2navigationcompletedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2navigationcompletedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2navigationstartingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2navigationstartingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2navigationstartingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2navigationstartingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2newversionavailableeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2newversionavailableeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2newversionavailableeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2newversionavailableeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2newwindowrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2newwindowrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2newwindowrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2newwindowrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2permissionrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2permissionrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2permissionrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2permissionrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2processfailedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2processfailedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2processfailedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2processfailedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2scriptdialogopeningeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2scriptdialogopeningeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2scriptdialogopeningeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2scriptdialogopeningeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2settings.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2settings2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2settings2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webmessagereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webmessagereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webmessagereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webmessagereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webresourcerequest.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webresourcerequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webresourcerequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webresourcerequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webresourcerequestedeventargs2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webresourcerequestedeventargs2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webresourcerequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webresourcerequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webresourceresponse.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webresourceresponse",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webview.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webview2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webview3.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webview3",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webview4.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webview4",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2webview5.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2webview5",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-8-190/iwebview2zoomfactorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/iwebview2zoomfactorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2acceleratorkeypressedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2acceleratorkeypressedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2calldevtoolsprotocolmethodcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2capturepreviewcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2capturepreviewcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2containsfullscreenelementchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2containsfullscreenelementchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2contentloadingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2contentloadingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2createcorewebview2environmentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2environmentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2createcorewebview2hostcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2hostcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2deferral.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2deferral",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2devtoolsprotocoleventreceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2devtoolsprotocoleventreceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2devtoolsprotocoleventreceiver.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceiver",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2documenttitlechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2documenttitlechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2environment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2executescriptcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2executescriptcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2focuschangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2focuschangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2historychangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2historychangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2host.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2httpheaderscollectioniterator.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2httprequestheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2httpresponseheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2movefocusrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2movefocusrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2navigationcompletedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2navigationcompletedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2navigationstartingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2navigationstartingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2newbrowserversionavailableeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newbrowserversionavailableeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2newbrowserversionavailableeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newbrowserversionavailableeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2newwindowrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2newwindowrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2permissionrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2permissionrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2processfailedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2processfailedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2scriptdialogopeningeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2scriptdialogopeningeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2settings.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2sourcechangedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2sourcechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2webmessagereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2webmessagereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2webresourcerequest.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2webresourcerequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2webresourcerequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2webresourceresponse.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponse",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2windowcloserequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2windowcloserequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-430/icorewebview2zoomfactorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2zoomfactorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2acceleratorkeypressedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2acceleratorkeypressedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2calldevtoolsprotocolmethodcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2capturepreviewcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2capturepreviewcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2containsfullscreenelementchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2containsfullscreenelementchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2contentloadingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2contentloadingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2controller.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2controller",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2createcorewebview2controllercompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2controllercompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2createcorewebview2environmentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2environmentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2deferral.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2deferral",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2devtoolsprotocoleventreceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2devtoolsprotocoleventreceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2devtoolsprotocoleventreceiver.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceiver",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2documenttitlechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2documenttitlechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2environment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2environmentoptions.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2executescriptcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2executescriptcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2experimentalcompositioncontroller.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontroller",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2experimentalcreatecorewebview2compositioncontrollercompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcreatecorewebview2compositioncontrollercompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2experimentalcursorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcursorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2experimentalenvironment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalenvironment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2experimentalpointerinfo.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalpointerinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2focuschangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2focuschangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2historychangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2historychangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2httpheaderscollectioniterator.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2httprequestheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2httpresponseheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2movefocusrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2movefocusrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2navigationcompletedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2navigationcompletedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2navigationstartingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2navigationstartingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2newbrowserversionavailableeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newbrowserversionavailableeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2newwindowrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2newwindowrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2permissionrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2permissionrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2processfailedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2processfailedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2scriptdialogopeningeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2scriptdialogopeningeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2settings.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2sourcechangedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2sourcechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2webmessagereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2webmessagereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2webresourcerequest.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2webresourcerequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2webresourcerequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2webresourceresponse.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponse",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2windowcloserequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2windowcloserequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-488/icorewebview2zoomfactorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2zoomfactorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2acceleratorkeypressedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2acceleratorkeypressedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2calldevtoolsprotocolmethodcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2capturepreviewcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2capturepreviewcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2containsfullscreenelementchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2containsfullscreenelementchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2contentloadingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2contentloadingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2controller.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2controller",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2createcorewebview2controllercompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2controllercompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2createcorewebview2environmentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2environmentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2deferral.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2deferral",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2devtoolsprotocoleventreceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2devtoolsprotocoleventreceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2devtoolsprotocoleventreceiver.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceiver",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2documenttitlechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2documenttitlechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2environment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2environmentoptions.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2executescriptcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2executescriptcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimental.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimental",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalcompositioncontroller.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontroller",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalcreatecorewebview2compositioncontrollercompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcreatecorewebview2compositioncontrollercompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalcursorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcursorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalenvironment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalenvironment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalenvironmentoptions.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalenvironmentoptions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalnewwindowrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalnewwindowrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalpointerinfo.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalpointerinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalwebresourceresponsereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebresourceresponsereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalwebresourceresponsereceivedeventargspopulateresponsecontentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebresourceresponsereceivedeventargspopulateresponsecontentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalwebresourceresponsereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebresourceresponsereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2experimentalwindowfeatures.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwindowfeatures",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2focuschangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2focuschangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2historychangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2historychangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2httpheaderscollectioniterator.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2httprequestheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2httpresponseheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2movefocusrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2movefocusrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2navigationcompletedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2navigationcompletedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2navigationstartingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2navigationstartingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2newbrowserversionavailableeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newbrowserversionavailableeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2newwindowrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2newwindowrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2permissionrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2permissionrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2processfailedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2processfailedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2scriptdialogopeningeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2scriptdialogopeningeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2settings.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2sourcechangedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2sourcechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2webmessagereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2webmessagereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2webresourcerequest.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2webresourcerequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2webresourcerequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2webresourceresponse.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponse",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2windowcloserequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2windowcloserequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-538/icorewebview2zoomfactorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2zoomfactorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2acceleratorkeypressedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2acceleratorkeypressedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2calldevtoolsprotocolmethodcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2capturepreviewcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2capturepreviewcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2containsfullscreenelementchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2containsfullscreenelementchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2contentloadingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2contentloadingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2controller.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2controller",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2createcorewebview2controllercompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2controllercompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2createcorewebview2environmentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2createcorewebview2environmentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2deferral.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2deferral",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2devtoolsprotocoleventreceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2devtoolsprotocoleventreceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2devtoolsprotocoleventreceiver.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceiver",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2documenttitlechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2documenttitlechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2environment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2environmentoptions.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2executescriptcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2executescriptcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimental.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimental",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalcompositioncontroller.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontroller",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalcreatecorewebview2compositioncontrollercompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcreatecorewebview2compositioncontrollercompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalcursorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcursorchangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalenvironment.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalenvironment",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalpointerinfo.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalpointerinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalwebresourceresponsereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebresourceresponsereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalwebresourceresponsereceivedeventargspopulateresponsecontentcompletedhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebresourceresponsereceivedeventargspopulateresponsecontentcompletedhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2experimentalwebresourceresponsereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebresourceresponsereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2focuschangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2focuschangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2historychangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2historychangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2httpheaderscollectioniterator.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2httprequestheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2httpresponseheaders.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2movefocusrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2movefocusrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2navigationcompletedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2navigationcompletedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2navigationstartingeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2navigationstartingeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2newbrowserversionavailableeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newbrowserversionavailableeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2newwindowrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2newwindowrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2permissionrequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2permissionrequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2processfailedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2processfailedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2scriptdialogopeningeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2scriptdialogopeningeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2settings.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2sourcechangedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2sourcechangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2webmessagereceivedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2webmessagereceivedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2webresourcerequest.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2webresourcerequestedeventargs.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2webresourcerequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2webresourceresponse.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponse",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2windowcloserequestedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2windowcloserequestedeventhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2windowfeatures.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2windowfeatures",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "non-version/0-9-622/icorewebview2zoomfactorchangedeventhandler.md",
+      "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2zoomfactorchangedeventhandler",
+      "redirect_document_id": false
+    }
+  ]
+}

--- a/docfx.json
+++ b/docfx.json
@@ -22,6 +22,12 @@
       },
       {
         "files": [
+          "**/*.md"
+        ],
+        "src": "non-version"
+      },
+      {
+        "files": [
           "**/*.md",
           "**/*.yml"
         ],


### PR DESCRIPTION
The PR is to properly redirects all the old WebView2 Win32 reference content at URLs `https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/<version>/<interface>` to `https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/<interface>`.

The fix is advised by the SRE team @mingwli 

> ... All redirection need to be put into an independent non version path ...
> - put all redirect source_path in a non-version folder
> - add those into build scope inside docfx.json