### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/0-9-430/icorewebview2host.md
+++ b/0-9-430/icorewebview2host.md
@@ -492,7 +492,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createwebview2environmentwithdetails?view=webview2-0.9.430
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createwebview2environmentwithdetails?view=webview2-0.9.430
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -551,4 +551,3 @@ A structure representing the information packed into the LPARAM given to a Win32
 > typedef [CORE_WEBVIEW2_PHYSICAL_KEY_STATUS](#core_webview2_physical_key_status)
 
 See the documentation for [WM_KEYDOWN](/windows/win32/inputdev/wm-keydown) for details.
-

--- a/0-9-488-prerelease/icorewebview2controller.md
+++ b/0-9-488-prerelease/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/webview2-idl#createwebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/webview2-idl#createwebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-488/icorewebview2controller.md
+++ b/0-9-488/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/webview2-idl#createwebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/webview2-idl#createwebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-515-prerelease/icorewebview2controller.md
+++ b/0-9-515-prerelease/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-538-prerelease/icorewebview2controller.md
+++ b/0-9-538-prerelease/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-538/icorewebview2controller.md
+++ b/0-9-538/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-579-prerelease/icorewebview2controller.md
+++ b/0-9-579-prerelease/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-579/icorewebview2controller.md
+++ b/0-9-579/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -531,4 +531,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-622-11/icorewebview2controller.md
+++ b/0-9-622-11/icorewebview2controller.md
@@ -223,7 +223,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -541,4 +541,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/0-9-628-prerelease/icorewebview2controller.md
+++ b/0-9-628-prerelease/icorewebview2controller.md
@@ -223,7 +223,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -541,4 +541,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-622-22/icorewebview2controller.md
+++ b/1-0-622-22/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -543,4 +543,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-664-37/icorewebview2controller.md
+++ b/1-0-664-37/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -543,4 +543,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-674-prerelease/icorewebview2controller.md
+++ b/1-0-674-prerelease/icorewebview2controller.md
@@ -225,7 +225,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -543,4 +543,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-705-50/icorewebview2controller.md
+++ b/1-0-705-50/icorewebview2controller.md
@@ -234,7 +234,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -556,4 +556,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-721-prerelease/icorewebview2controller.md
+++ b/1-0-721-prerelease/icorewebview2controller.md
@@ -227,7 +227,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -549,4 +549,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-774-44/icorewebview2controller.md
+++ b/1-0-774-44/icorewebview2controller.md
@@ -234,7 +234,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -558,4 +558,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-790-prerelease/icorewebview2controller.md
+++ b/1-0-790-prerelease/icorewebview2controller.md
@@ -234,7 +234,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -558,4 +558,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-818-41/icorewebview2controller.md
+++ b/1-0-818-41/icorewebview2controller.md
@@ -235,7 +235,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -559,4 +559,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-824-prerelease/icorewebview2controller.md
+++ b/1-0-824-prerelease/icorewebview2controller.md
@@ -235,7 +235,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -559,4 +559,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-864-35/icorewebview2controller.md
+++ b/1-0-864-35/icorewebview2controller.md
@@ -235,7 +235,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -559,4 +559,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-

--- a/1-0-865-prerelease/icorewebview2controller.md
+++ b/1-0-865-prerelease/icorewebview2controller.md
@@ -235,7 +235,7 @@ void AppWindow::CloseWebView(bool cleanupUserDataFolder)
         // developers specify userDataFolder during WebView environment
         // creation, they would need to pass in that explicit value here.
         // For more information about userDataFolder:
-        // https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
+        // https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
         WCHAR userDataFolder[MAX_PATH] = L"";
         // Obtain the absolute path for relative paths that include "./" or "../"
         _wfullpath(
@@ -559,4 +559,3 @@ void ViewComponent::SetScale(float scale)
     m_controller->SetBoundsAndZoomFactor(bounds, scale);
 }
 ```
-


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
