### PR TITLE
WebView2: Update documentation for ICoreWebView2LaunchingExternalUriSchemeEventArgs.get_InitiatingOrigin

### DIFF
--- a/1-0-2277-86/icorewebview2.md
+++ b/1-0-2277-86/icorewebview2.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 enables you to host web content using the latest Microsoft Edge browser and web technology.
 title: WebView2 Win32 C++ ICoreWebView2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_10.md
+++ b/1-0-2277-86/icorewebview2_10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_9 that supports BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_10
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_11.md
+++ b/1-0-2277-86/icorewebview2_11.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_10 that supports sessionId for CDP method calls and ContextMenuRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_11
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_12.md
+++ b/1-0-2277-86/icorewebview2_12.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_11 that supports StatusBarTextChanged event.
 title: WebView2 Win32 C++ ICoreWebView2_12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_12
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_13.md
+++ b/1-0-2277-86/icorewebview2_13.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_12 that supports Profile API.
 title: WebView2 Win32 C++ ICoreWebView2_13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_13
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_14.md
+++ b/1-0-2277-86/icorewebview2_14.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_13 that adds ServerCertificate support.
 title: WebView2 Win32 C++ ICoreWebView2_14
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_14
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_15.md
+++ b/1-0-2277-86/icorewebview2_15.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_14 that supports status Favicons.
 title: WebView2 Win32 C++ ICoreWebView2_15
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_15
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_16.md
+++ b/1-0-2277-86/icorewebview2_16.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface to support printing.
 title: WebView2 Win32 C++ ICoreWebView2_16
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_16
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_17.md
+++ b/1-0-2277-86/icorewebview2_17.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_16 that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2_17
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_17
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_18.md
+++ b/1-0-2277-86/icorewebview2_18.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_17 that manages navigation requests to URI schemes registered with the OS.
 title: WebView2 Win32 C++ ICoreWebView2_18
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_18
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_19.md
+++ b/1-0-2277-86/icorewebview2_19.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_18 that manages memory usage target level.
 title: WebView2 Win32 C++ ICoreWebView2_19
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_19
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_2.md
+++ b/1-0-2277-86/icorewebview2_2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_20.md
+++ b/1-0-2277-86/icorewebview2_20.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_19 that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2_20
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_20
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_21.md
+++ b/1-0-2277-86/icorewebview2_21.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface for getting string and exception with ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2_21
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_21
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_3.md
+++ b/1-0-2277-86/icorewebview2_3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_4.md
+++ b/1-0-2277-86/icorewebview2_4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_3 interface to support FrameCreated and DownloadStarting events.
 title: WebView2 Win32 C++ ICoreWebView2_4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_5.md
+++ b/1-0-2277-86/icorewebview2_5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_4 interface to support ClientCertificateRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_5
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_6.md
+++ b/1-0-2277-86/icorewebview2_6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_5 that manages opening the browser task manager window.
 title: WebView2 Win32 C++ ICoreWebView2_6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_6
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_7.md
+++ b/1-0-2277-86/icorewebview2_7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_6 that supports printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2_7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_7
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_8.md
+++ b/1-0-2277-86/icorewebview2_8.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_7 that supports media features.
 title: WebView2 Win32 C++ ICoreWebView2_8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_8
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2_9.md
+++ b/1-0-2277-86/icorewebview2_9.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_8 that default download dialog positioning and anchoring.
 title: WebView2 Win32 C++ ICoreWebView2_9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_9
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2acceleratorkeypressedeventargs.md
+++ b/1-0-2277-86/icorewebview2acceleratorkeypressedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `AcceleratorKeyPressed` event.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2acceleratorkeypressedeventargs2.md
+++ b/1-0-2277-86/icorewebview2acceleratorkeypressedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is This is a continuation of the ICoreWebView2AcceleratorKeyPressedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2acceleratorkeypressedeventhandler.md
+++ b/1-0-2277-86/icorewebview2acceleratorkeypressedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `AcceleratorKeyPressed` events.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `AddScriptToExecuteOnDocumentCreated` method.
 title: WebView2 Win32 C++ ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2basicauthenticationrequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2basicauthenticationrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2basicauthenticationrequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2basicauthenticationrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2basicauthenticationresponse.md
+++ b/1-0-2277-86/icorewebview2basicauthenticationresponse.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a Basic HTTP authentication response that contains a user name and a password as according to RFC7617 (https://tools.ietf.org/html/rfc7617)
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationResponse
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2browserextension.md
+++ b/1-0-2277-86/icorewebview2browserextension.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing an Extension, which includes an ID, name, and whether it is enabled or not, and the ability to Remove the Extension, and enable or disable it.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtension
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtension
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2browserextensionenablecompletedhandler.md
+++ b/1-0-2277-86/icorewebview2browserextensionenablecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of setting the browser Extension as enabled or disabled.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionEnableCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionEnableCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2browserextensionlist.md
+++ b/1-0-2277-86/icorewebview2browserextensionlist.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing browser Extension Lists from user profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionList
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2browserextensionremovecompletedhandler.md
+++ b/1-0-2277-86/icorewebview2browserextensionremovecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of removing the browser Extension from the Profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionRemoveCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionRemoveCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2browserprocessexitedeventargs.md
+++ b/1-0-2277-86/icorewebview2browserprocessexitedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2browserprocessexitedeventhandler.md
+++ b/1-0-2277-86/icorewebview2browserprocessexitedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `BrowserProcessExited` events.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2bytesreceivedchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2bytesreceivedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `BytesReceivedChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2BytesReceivedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BytesReceivedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `CallDevToolsProtocolMethod` completion results.
 title: WebView2 Win32 C++ ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2capturepreviewcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2capturepreviewcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `CapturePreview` method.
 title: WebView2 Win32 C++ ICoreWebView2CapturePreviewCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CapturePreviewCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2certificate.md
+++ b/1-0-2277-86/icorewebview2certificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2Certificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Certificate
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2clearbrowsingdatacompletedhandler.md
+++ b/1-0-2277-86/icorewebview2clearbrowsingdatacompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the ClearBrowsingData result.
 title: WebView2 Win32 C++ ICoreWebView2ClearBrowsingDataCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearBrowsingDataCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2clearservercertificateerroractionscompletedhandler.md
+++ b/1-0-2277-86/icorewebview2clearservercertificateerroractionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ClearServerCertificateErrorActions` method.
 title: WebView2 Win32 C++ ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2clientcertificate.md
+++ b/1-0-2277-86/icorewebview2clientcertificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the client certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificate
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2clientcertificatecollection.md
+++ b/1-0-2277-86/icorewebview2clientcertificatecollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of client certificate object.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateCollection
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2clientcertificaterequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2clientcertificaterequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2clientcertificaterequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2clientcertificaterequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2compositioncontroller.md
+++ b/1-0-2277-86/icorewebview2compositioncontroller.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Controller interface to support visual hosting.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2compositioncontroller2.md
+++ b/1-0-2277-86/icorewebview2compositioncontroller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2CompositionController interface.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2compositioncontroller3.md
+++ b/1-0-2277-86/icorewebview2compositioncontroller3.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is the continuation of the ICoreWebView2CompositionController2 interface to manage drag and drop.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2containsfullscreenelementchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2containsfullscreenelementchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContainsFullScreenElementChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ContainsFullScreenElementChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContainsFullScreenElementChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contentloadingeventargs.md
+++ b/1-0-2277-86/icorewebview2contentloadingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContentLoading` event.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contentloadingeventhandler.md
+++ b/1-0-2277-86/icorewebview2contentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contextmenuitem.md
+++ b/1-0-2277-86/icorewebview2contextmenuitem.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a context menu item of a context menu displayed by WebView.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItem
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItem
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contextmenuitemcollection.md
+++ b/1-0-2277-86/icorewebview2contextmenuitemcollection.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a collection of `ContextMenuItem` objects.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItemCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItemCollection
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contextmenurequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2contextmenurequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContextMenuRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contextmenurequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2contextmenurequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContextMenuRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2contextmenutarget.md
+++ b/1-0-2277-86/icorewebview2contextmenutarget.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the information regarding the context menu target.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuTarget
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuTarget
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2controller.md
+++ b/1-0-2277-86/icorewebview2controller.md
@@ -1,7 +1,7 @@
 ---
 description: The owner of the `CoreWebView2` object that provides support for resizing, showing and hiding, focusing, and other functionality related to windowing and composition.
 title: WebView2 Win32 C++ ICoreWebView2Controller
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2controller2.md
+++ b/1-0-2277-86/icorewebview2controller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2controller3.md
+++ b/1-0-2277-86/icorewebview2controller3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2controller4.md
+++ b/1-0-2277-86/icorewebview2controller4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Controller4 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2controlleroptions.md
+++ b/1-0-2277-86/icorewebview2controlleroptions.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to manage profile options that created by 'CreateCoreWebView2ControllerOptions'.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2controlleroptions2.md
+++ b/1-0-2277-86/icorewebview2controlleroptions2.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface in ControllerOptions for ScriptLocale.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2cookie.md
+++ b/1-0-2277-86/icorewebview2cookie.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties that are used to manage an ICoreWebView2Cookie.
 title: WebView2 Win32 C++ ICoreWebView2Cookie
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Cookie
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2cookielist.md
+++ b/1-0-2277-86/icorewebview2cookielist.md
@@ -1,7 +1,7 @@
 ---
 description: A list of cookie objects.
 title: WebView2 Win32 C++ ICoreWebView2CookieList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieList
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2cookiemanager.md
+++ b/1-0-2277-86/icorewebview2cookiemanager.md
@@ -1,7 +1,7 @@
 ---
 description: Creates, adds or updates, gets, or or view the cookies.
 title: WebView2 Win32 C++ ICoreWebView2CookieManager
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieManager
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
+++ b/1-0-2277-86/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the CoreWebView2Controller created via CreateCoreWebView2CompositionController.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2createcorewebview2controllercompletedhandler.md
+++ b/1-0-2277-86/icorewebview2createcorewebview2controllercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Controller` created using `CreateCoreWebView2Controller`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2createcorewebview2environmentcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2createcorewebview2environmentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `WebView2Environment` created using `CreateCoreWebView2Environment`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2cursorchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2cursorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive CursorChanged events.
 title: WebView2 Win32 C++ ICoreWebView2CursorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CursorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2customitemselectedeventhandler.md
+++ b/1-0-2277-86/icorewebview2customitemselectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Raised to notify the host that the end user selected a custom `ContextMenuItem`.
 title: WebView2 Win32 C++ ICoreWebView2CustomItemSelectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomItemSelectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2customschemeregistration.md
+++ b/1-0-2277-86/icorewebview2customschemeregistration.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the registration of a custom scheme with the CoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2CustomSchemeRegistration
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomSchemeRegistration
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2deferral.md
+++ b/1-0-2277-86/icorewebview2deferral.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to complete deferrals on event args that support getting deferrals using the `GetDeferral` method.
 title: WebView2 Win32 C++ ICoreWebView2Deferral
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Deferral
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2devtoolsprotocoleventreceivedeventargs.md
+++ b/1-0-2277-86/icorewebview2devtoolsprotocoleventreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DevToolsProtocolEventReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
+++ b/1-0-2277-86/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2DevToolsProtocolEventReceivedEventArgs interface that provides the session ID of the target where the event originates from.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
+++ b/1-0-2277-86/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DevToolsProtocolEventReceived` events from the WebView.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2devtoolsprotocoleventreceiver.md
+++ b/1-0-2277-86/icorewebview2devtoolsprotocoleventreceiver.md
@@ -1,7 +1,7 @@
 ---
 description: A Receiver is created for a particular DevTools Protocol event and allows you to subscribe and unsubscribe from that event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceiver
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceiver
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2documenttitlechangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2documenttitlechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DocumentTitleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2DocumentTitleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DocumentTitleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2domcontentloadedeventargs.md
+++ b/1-0-2277-86/icorewebview2domcontentloadedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the DOMContentLoaded event.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2domcontentloadedeventhandler.md
+++ b/1-0-2277-86/icorewebview2domcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2downloadoperation.md
+++ b/1-0-2277-86/icorewebview2downloadoperation.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a download operation.
 title: WebView2 Win32 C++ ICoreWebView2DownloadOperation
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadOperation
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2downloadstartingeventargs.md
+++ b/1-0-2277-86/icorewebview2downloadstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2downloadstartingeventhandler.md
+++ b/1-0-2277-86/icorewebview2downloadstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Add an event handler for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment.md
+++ b/1-0-2277-86/icorewebview2environment.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment10.md
+++ b/1-0-2277-86/icorewebview2environment10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to create ICoreWebView2ControllerOptions object, which can be passed as a parameter in `CreateCoreWebView2ControllerWithOptions` and `CreateCoreWebView2CompositionControllerWithOptions` function for multiple profiles support.
 title: WebView2 Win32 C++ ICoreWebView2Environment10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment10
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment11.md
+++ b/1-0-2277-86/icorewebview2environment11.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting the crash dump folder path.
 title: WebView2 Win32 C++ ICoreWebView2Environment11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment11
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment12.md
+++ b/1-0-2277-86/icorewebview2environment12.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating shared buffer object.
 title: WebView2 Win32 C++ ICoreWebView2Environment12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment12
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment13.md
+++ b/1-0-2277-86/icorewebview2environment13.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting process with associated information.
 title: WebView2 Win32 C++ ICoreWebView2Environment13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment13
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment2.md
+++ b/1-0-2277-86/icorewebview2environment2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment3.md
+++ b/1-0-2277-86/icorewebview2environment3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment4.md
+++ b/1-0-2277-86/icorewebview2environment4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment3 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment5.md
+++ b/1-0-2277-86/icorewebview2environment5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment4 interface that supports the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment5
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment6.md
+++ b/1-0-2277-86/icorewebview2environment6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment that supports creating print settings for printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2Environment6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment6
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment7.md
+++ b/1-0-2277-86/icorewebview2environment7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment7
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment8.md
+++ b/1-0-2277-86/icorewebview2environment8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment7 interface that supports the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment8
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environment9.md
+++ b/1-0-2277-86/icorewebview2environment9.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating CoreWebView2 ContextMenuItem objects.
 title: WebView2 Win32 C++ ICoreWebView2Environment9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment9
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environmentoptions.md
+++ b/1-0-2277-86/icorewebview2environmentoptions.md
@@ -1,7 +1,7 @@
 ---
 description: Options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environmentoptions2.md
+++ b/1-0-2277-86/icorewebview2environmentoptions2.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environmentoptions3.md
+++ b/1-0-2277-86/icorewebview2environmentoptions3.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage crash reporting.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environmentoptions4.md
+++ b/1-0-2277-86/icorewebview2environmentoptions4.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment that manages custom scheme registration.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environmentoptions5.md
+++ b/1-0-2277-86/icorewebview2environmentoptions5.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions5
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2environmentoptions6.md
+++ b/1-0-2277-86/icorewebview2environmentoptions6.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions6
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2estimatedendtimechangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2estimatedendtimechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `EstimatedEndTimeChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2EstimatedEndTimeChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EstimatedEndTimeChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2executescriptcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2executescriptcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ExecuteScript` method.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2executescriptresult.md
+++ b/1-0-2277-86/icorewebview2executescriptresult.md
@@ -1,7 +1,7 @@
 ---
 description: This is the result for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptResult
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptResult
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2executescriptwithresultcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2executescriptwithresultcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptWithResultCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptWithResultCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2faviconchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2faviconchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for when the `Favicon` is changed.
 title: WebView2 Win32 C++ ICoreWebView2FaviconChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FaviconChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2file.md
+++ b/1-0-2277-86/icorewebview2file.md
@@ -1,7 +1,7 @@
 ---
 description: Representation of a DOM File object passed via WebMessage.
 title: WebView2 Win32 C++ ICoreWebView2File
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2File
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2focuschangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2focuschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `GotFocus` and `LostFocus` events.
 title: WebView2 Win32 C++ ICoreWebView2FocusChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FocusChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frame.md
+++ b/1-0-2277-86/icorewebview2frame.md
@@ -1,7 +1,7 @@
 ---
 description: ICoreWebView2Frame provides direct access to the iframes information.
 title: WebView2 Win32 C++ ICoreWebView2Frame
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frame2.md
+++ b/1-0-2277-86/icorewebview2frame2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Frame interface with navigation events, executing script and posting web messages.
 title: WebView2 Win32 C++ ICoreWebView2Frame2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frame3.md
+++ b/1-0-2277-86/icorewebview2frame3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports PermissionRequested.
 title: WebView2 Win32 C++ ICoreWebView2Frame3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frame4.md
+++ b/1-0-2277-86/icorewebview2frame4.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2Frame4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frame5.md
+++ b/1-0-2277-86/icorewebview2frame5.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2Frame5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame5
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framecontentloadingeventhandler.md
+++ b/1-0-2277-86/icorewebview2framecontentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framecreatedeventargs.md
+++ b/1-0-2277-86/icorewebview2framecreatedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `FrameCreated` events.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framecreatedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framecreatedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameCreated` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framedestroyedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framedestroyedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameDestroyed` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameDestroyedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDestroyedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framedomcontentloadedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framedomcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameDOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frameinfo.md
+++ b/1-0-2277-86/icorewebview2frameinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a frame in the ICoreWebView2.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frameinfo2.md
+++ b/1-0-2277-86/icorewebview2frameinfo2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2FrameInfo interface that provides `ParentFrameInfo`, `FrameId` and `FrameKind` properties.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frameinfocollection.md
+++ b/1-0-2277-86/icorewebview2frameinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: Collection of `FrameInfo`s (name and source).
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2frameinfocollectioniterator.md
+++ b/1-0-2277-86/icorewebview2frameinfocollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of `FrameInfo`s.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framenamechangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framenamechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameNameChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameNameChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNameChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framenavigationcompletedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framenavigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framenavigationstartingeventhandler.md
+++ b/1-0-2277-86/icorewebview2framenavigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framepermissionrequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framepermissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events for iframes.
 title: WebView2 Win32 C++ ICoreWebView2FramePermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FramePermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2framewebmessagereceivedeventhandler.md
+++ b/1-0-2277-86/icorewebview2framewebmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameWebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameWebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2getcookiescompletedhandler.md
+++ b/1-0-2277-86/icorewebview2getcookiescompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetCookies` method.
 title: WebView2 Win32 C++ ICoreWebView2GetCookiesCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetCookiesCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2getfaviconcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2getfaviconcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for the completion of the population of `imageStream`.
 title: WebView2 Win32 C++ ICoreWebView2GetFaviconCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetFaviconCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
+++ b/1-0-2277-86/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `GetNonDefaultPermissionSettings`.
 title: WebView2 Win32 C++ ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2getprocessextendedinfoscompletedhandler.md
+++ b/1-0-2277-86/icorewebview2getprocessextendedinfoscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetProcessExtendedInfos` method.
 title: WebView2 Win32 C++ ICoreWebView2GetProcessExtendedInfosCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetProcessExtendedInfosCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2historychangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2historychangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `HistoryChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2HistoryChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HistoryChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2httpheaderscollectioniterator.md
+++ b/1-0-2277-86/icorewebview2httpheaderscollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of HTTP headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpHeadersCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpHeadersCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2httprequestheaders.md
+++ b/1-0-2277-86/icorewebview2httprequestheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP request headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpRequestHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpRequestHeaders
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2httpresponseheaders.md
+++ b/1-0-2277-86/icorewebview2httpresponseheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP response headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpResponseHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpResponseHeaders
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDefaultDownloadDialogOpenChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2isdocumentplayingaudiochangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2isdocumentplayingaudiochangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDocumentPlayingAudioChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2ismutedchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2ismutedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsMutedChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsMutedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsMutedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2launchingexternalurischemeeventargs.md
+++ b/1-0-2277-86/icorewebview2launchingexternalurischemeeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2launchingexternalurischemeeventhandler.md
+++ b/1-0-2277-86/icorewebview2launchingexternalurischemeeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Event handler for the `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2movefocusrequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2movefocusrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `MoveFocusRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2movefocusrequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2movefocusrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `MoveFocusRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationcompletedeventargs.md
+++ b/1-0-2277-86/icorewebview2navigationcompletedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationCompleted` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationcompletedeventargs2.md
+++ b/1-0-2277-86/icorewebview2navigationcompletedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is an interface for the StatusCode property of ICoreWebView2NavigationCompletedEventArgs.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationcompletedeventhandler.md
+++ b/1-0-2277-86/icorewebview2navigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationstartingeventargs.md
+++ b/1-0-2277-86/icorewebview2navigationstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationstartingeventargs2.md
+++ b/1-0-2277-86/icorewebview2navigationstartingeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: The AdditionalAllowedFrameAncestors API that enable developers to provide additional allowed frame ancestors.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationstartingeventargs3.md
+++ b/1-0-2277-86/icorewebview2navigationstartingeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: The NavigationKind API that enables developers to get more information about navigation type.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2navigationstartingeventhandler.md
+++ b/1-0-2277-86/icorewebview2navigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2newbrowserversionavailableeventhandler.md
+++ b/1-0-2277-86/icorewebview2newbrowserversionavailableeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewBrowserVersionAvailable` events.
 title: WebView2 Win32 C++ ICoreWebView2NewBrowserVersionAvailableEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewBrowserVersionAvailableEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2newwindowrequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2newwindowrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NewWindowRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2newwindowrequestedeventargs2.md
+++ b/1-0-2277-86/icorewebview2newwindowrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2newwindowrequestedeventargs3.md
+++ b/1-0-2277-86/icorewebview2newwindowrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2newwindowrequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2newwindowrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewWindowRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2objectcollectionview.md
+++ b/1-0-2277-86/icorewebview2objectcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of generic objects.
 title: WebView2 Win32 C++ ICoreWebView2ObjectCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ObjectCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2permissionrequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2permissionrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `PermissionRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2permissionrequestedeventargs2.md
+++ b/1-0-2277-86/icorewebview2permissionrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2permissionrequestedeventargs3.md
+++ b/1-0-2277-86/icorewebview2permissionrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs2 interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2permissionrequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2permissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2permissionsetting.md
+++ b/1-0-2277-86/icorewebview2permissionsetting.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a permission setting.
 title: WebView2 Win32 C++ ICoreWebView2PermissionSetting
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSetting
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2permissionsettingcollectionview.md
+++ b/1-0-2277-86/icorewebview2permissionsettingcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of `PermissionSetting`s (origin, kind, and state).
 title: WebView2 Win32 C++ ICoreWebView2PermissionSettingCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSettingCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2pointerinfo.md
+++ b/1-0-2277-86/icorewebview2pointerinfo.md
@@ -1,7 +1,7 @@
 ---
 description: This mostly represents a combined win32 POINTER_INFO/POINTER_TOUCH_INFO/POINTER_PEN_INFO object.
 title: WebView2 Win32 C++ ICoreWebView2PointerInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PointerInfo
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2printcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2printcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2printsettings.md
+++ b/1-0-2277-86/icorewebview2printsettings.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2printsettings2.md
+++ b/1-0-2277-86/icorewebview2printsettings2.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2printtopdfcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2printtopdfcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2printtopdfstreamcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2printtopdfstreamcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdfStream` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfStreamCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfStreamCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processextendedinfo.md
+++ b/1-0-2277-86/icorewebview2processextendedinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides process with associated extended information in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfo
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processextendedinfocollection.md
+++ b/1-0-2277-86/icorewebview2processextendedinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing processInfo and associated extended information.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processfailedeventargs.md
+++ b/1-0-2277-86/icorewebview2processfailedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ProcessFailed` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processfailedeventargs2.md
+++ b/1-0-2277-86/icorewebview2processfailedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2ProcessFailedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processfailedeventhandler.md
+++ b/1-0-2277-86/icorewebview2processfailedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ProcessFailed` events.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processinfo.md
+++ b/1-0-2277-86/icorewebview2processinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a process in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfo
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processinfocollection.md
+++ b/1-0-2277-86/icorewebview2processinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing process id and corresponding process type.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2processinfoschangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2processinfoschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfosChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfosChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile.md
+++ b/1-0-2277-86/icorewebview2profile.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties to configure a Profile object.
 title: WebView2 Win32 C++ ICoreWebView2Profile
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile2.md
+++ b/1-0-2277-86/icorewebview2profile2.md
@@ -1,7 +1,7 @@
 ---
 description: Profile2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Profile2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile3.md
+++ b/1-0-2277-86/icorewebview2profile3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Profile interface to control levels of tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2Profile3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile4.md
+++ b/1-0-2277-86/icorewebview2profile4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for the permission management APIs.
 title: WebView2 Win32 C++ ICoreWebView2Profile4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile5.md
+++ b/1-0-2277-86/icorewebview2profile5.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for cookie manager.
 title: WebView2 Win32 C++ ICoreWebView2Profile5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile5
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile6.md
+++ b/1-0-2277-86/icorewebview2profile6.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing password-autosave and general-autofill.
 title: WebView2 Win32 C++ ICoreWebView2Profile6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile6
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile7.md
+++ b/1-0-2277-86/icorewebview2profile7.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2Profile7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile7
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profile8.md
+++ b/1-0-2277-86/icorewebview2profile8.md
@@ -1,7 +1,7 @@
 ---
 description: This is the profile interface that manages profile deletion.
 title: WebView2 Win32 C++ ICoreWebView2Profile8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile8
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profileaddbrowserextensioncompletedhandler.md
+++ b/1-0-2277-86/icorewebview2profileaddbrowserextensioncompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of loading an browser Extension.
 title: WebView2 Win32 C++ ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profiledeletedeventhandler.md
+++ b/1-0-2277-86/icorewebview2profiledeletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Profile.Deleted` event.
 title: WebView2 Win32 C++ ICoreWebView2ProfileDeletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileDeletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2profilegetbrowserextensionscompletedhandler.md
+++ b/1-0-2277-86/icorewebview2profilegetbrowserextensionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of getting the browser Extensions.
 title: WebView2 Win32 C++ ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2rasterizationscalechangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2rasterizationscalechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `RasterizationScaleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2RasterizationScaleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2RasterizationScaleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2scriptdialogopeningeventargs.md
+++ b/1-0-2277-86/icorewebview2scriptdialogopeningeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ScriptDialogOpening` event.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2scriptdialogopeningeventhandler.md
+++ b/1-0-2277-86/icorewebview2scriptdialogopeningeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ScriptDialogOpening` events.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2scriptexception.md
+++ b/1-0-2277-86/icorewebview2scriptexception.md
@@ -1,7 +1,7 @@
 ---
 description: This interface represents a JavaScript exception.
 title: WebView2 Win32 C++ ICoreWebView2ScriptException
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptException
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2servercertificateerrordetectedeventargs.md
+++ b/1-0-2277-86/icorewebview2servercertificateerrordetectedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2servercertificateerrordetectedeventhandler.md
+++ b/1-0-2277-86/icorewebview2servercertificateerrordetectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2setpermissionstatecompletedhandler.md
+++ b/1-0-2277-86/icorewebview2setpermissionstatecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `SetPermissionState`.
 title: WebView2 Win32 C++ ICoreWebView2SetPermissionStateCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SetPermissionStateCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings.md
+++ b/1-0-2277-86/icorewebview2settings.md
@@ -1,7 +1,7 @@
 ---
 description: Defines properties that enable, disable, or modify WebView features.
 title: WebView2 Win32 C++ ICoreWebView2Settings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings2.md
+++ b/1-0-2277-86/icorewebview2settings2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages the user agent.
 title: WebView2 Win32 C++ ICoreWebView2Settings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings3.md
+++ b/1-0-2277-86/icorewebview2settings3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages whether browser accelerator keys are enabled.
 title: WebView2 Win32 C++ ICoreWebView2Settings3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings3
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings4.md
+++ b/1-0-2277-86/icorewebview2settings4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage autofill.
 title: WebView2 Win32 C++ ICoreWebView2Settings4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings4
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings5.md
+++ b/1-0-2277-86/icorewebview2settings5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage pinch zoom.
 title: WebView2 Win32 C++ ICoreWebView2Settings5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings5
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings6.md
+++ b/1-0-2277-86/icorewebview2settings6.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage swipe navigation.
 title: WebView2 Win32 C++ ICoreWebView2Settings6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings6
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings7.md
+++ b/1-0-2277-86/icorewebview2settings7.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to hide Pdf toolbar items.
 title: WebView2 Win32 C++ ICoreWebView2Settings7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings7
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2settings8.md
+++ b/1-0-2277-86/icorewebview2settings8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage smartscreen.
 title: WebView2 Win32 C++ ICoreWebView2Settings8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings8
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2sharedbuffer.md
+++ b/1-0-2277-86/icorewebview2sharedbuffer.md
@@ -1,7 +1,7 @@
 ---
 description: The shared buffer object that is created by CreateSharedBuffer.
 title: WebView2 Win32 C++ ICoreWebView2SharedBuffer
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SharedBuffer
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2sourcechangedeventargs.md
+++ b/1-0-2277-86/icorewebview2sourcechangedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `SourceChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2sourcechangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2sourcechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `SourceChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2statechangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2statechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `StateChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2StateChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StateChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2statusbartextchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2statusbartextchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `StatusBarTextChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2StatusBarTextChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StatusBarTextChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2stringcollection.md
+++ b/1-0-2277-86/icorewebview2stringcollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of strings.
 title: WebView2 Win32 C++ ICoreWebView2StringCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StringCollection
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2trysuspendcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2trysuspendcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the TrySuspend result.
 title: WebView2 Win32 C++ ICoreWebView2TrySuspendCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2TrySuspendCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webmessagereceivedeventargs.md
+++ b/1-0-2277-86/icorewebview2webmessagereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebMessageReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webmessagereceivedeventargs2.md
+++ b/1-0-2277-86/icorewebview2webmessagereceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Extension of WebMessageReceivedEventArgs to provide access to additional WebMessage objects.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webmessagereceivedeventhandler.md
+++ b/1-0-2277-86/icorewebview2webmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourcerequest.md
+++ b/1-0-2277-86/icorewebview2webresourcerequest.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP request used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequest
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequest
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourcerequestedeventargs.md
+++ b/1-0-2277-86/icorewebview2webresourcerequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourcerequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2webresourcerequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Runs when a URL request (through network, file, and so on) is made in the webview for a Web resource matching resource context filter and URL specified in `AddWebResourceRequestedFilter`.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourceresponse.md
+++ b/1-0-2277-86/icorewebview2webresourceresponse.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP response used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponse
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourceresponsereceivedeventargs.md
+++ b/1-0-2277-86/icorewebview2webresourceresponsereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the WebResourceResponseReceived event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourceresponsereceivedeventhandler.md
+++ b/1-0-2277-86/icorewebview2webresourceresponsereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebResourceResponseReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourceresponseview.md
+++ b/1-0-2277-86/icorewebview2webresourceresponseview.md
@@ -1,7 +1,7 @@
 ---
 description: View of the HTTP representation for a web resource response.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseView
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
+++ b/1-0-2277-86/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the ICoreWebView2WebResourceResponseView::GetContent method.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2windowcloserequestedeventhandler.md
+++ b/1-0-2277-86/icorewebview2windowcloserequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WindowCloseRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2WindowCloseRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowCloseRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2windowfeatures.md
+++ b/1-0-2277-86/icorewebview2windowfeatures.md
@@ -1,7 +1,7 @@
 ---
 description: The window features for a WebView popup window.
 title: WebView2 Win32 C++ ICoreWebView2WindowFeatures
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowFeatures
 topic_type: 
 - APIRef

--- a/1-0-2277-86/icorewebview2zoomfactorchangedeventhandler.md
+++ b/1-0-2277-86/icorewebview2zoomfactorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `ZoomFactorChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ZoomFactorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ZoomFactorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2277-86/index.md
+++ b/1-0-2277-86/index.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 C++ Reference
 title: WebView2 Win32 C++ Reference
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 ---
 

--- a/1-0-2277-86/webview2-idl.md
+++ b/1-0-2277-86/webview2-idl.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 Globals
 title: Globals
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2.md
+++ b/1-0-2357-prerelease/icorewebview2.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 enables you to host web content using the latest Microsoft Edge browser and web technology.
 title: WebView2 Win32 C++ ICoreWebView2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_10.md
+++ b/1-0-2357-prerelease/icorewebview2_10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_9 that supports BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_10
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_11.md
+++ b/1-0-2357-prerelease/icorewebview2_11.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_10 that supports sessionId for CDP method calls and ContextMenuRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_11
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_12.md
+++ b/1-0-2357-prerelease/icorewebview2_12.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_11 that supports StatusBarTextChanged event.
 title: WebView2 Win32 C++ ICoreWebView2_12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_12
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_13.md
+++ b/1-0-2357-prerelease/icorewebview2_13.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_12 that supports Profile API.
 title: WebView2 Win32 C++ ICoreWebView2_13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_13
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_14.md
+++ b/1-0-2357-prerelease/icorewebview2_14.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_13 that adds ServerCertificate support.
 title: WebView2 Win32 C++ ICoreWebView2_14
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_14
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_15.md
+++ b/1-0-2357-prerelease/icorewebview2_15.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_14 that supports status Favicons.
 title: WebView2 Win32 C++ ICoreWebView2_15
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_15
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_16.md
+++ b/1-0-2357-prerelease/icorewebview2_16.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface to support printing.
 title: WebView2 Win32 C++ ICoreWebView2_16
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_16
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_17.md
+++ b/1-0-2357-prerelease/icorewebview2_17.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_16 that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2_17
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_17
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_18.md
+++ b/1-0-2357-prerelease/icorewebview2_18.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_17 that manages navigation requests to URI schemes registered with the OS.
 title: WebView2 Win32 C++ ICoreWebView2_18
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_18
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_19.md
+++ b/1-0-2357-prerelease/icorewebview2_19.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_18 that manages memory usage target level.
 title: WebView2 Win32 C++ ICoreWebView2_19
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_19
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_2.md
+++ b/1-0-2357-prerelease/icorewebview2_2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_20.md
+++ b/1-0-2357-prerelease/icorewebview2_20.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_19 that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2_20
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_20
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_21.md
+++ b/1-0-2357-prerelease/icorewebview2_21.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface for getting string and exception with ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2_21
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_21
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_22.md
+++ b/1-0-2357-prerelease/icorewebview2_22.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2 that allows to set filters in order to receive WebResourceRequested events for service workers, shared workers and different origin iframes.
 title: WebView2 Win32 C++ ICoreWebView2_22
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_22
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_3.md
+++ b/1-0-2357-prerelease/icorewebview2_3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_4.md
+++ b/1-0-2357-prerelease/icorewebview2_4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_3 interface to support FrameCreated and DownloadStarting events.
 title: WebView2 Win32 C++ ICoreWebView2_4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_5.md
+++ b/1-0-2357-prerelease/icorewebview2_5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_4 interface to support ClientCertificateRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_6.md
+++ b/1-0-2357-prerelease/icorewebview2_6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_5 that manages opening the browser task manager window.
 title: WebView2 Win32 C++ ICoreWebView2_6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_6
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_7.md
+++ b/1-0-2357-prerelease/icorewebview2_7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_6 that supports printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2_7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_7
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_8.md
+++ b/1-0-2357-prerelease/icorewebview2_8.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_7 that supports media features.
 title: WebView2 Win32 C++ ICoreWebView2_8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_8
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2_9.md
+++ b/1-0-2357-prerelease/icorewebview2_9.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_8 that default download dialog positioning and anchoring.
 title: WebView2 Win32 C++ ICoreWebView2_9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_9
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2acceleratorkeypressedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2acceleratorkeypressedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `AcceleratorKeyPressed` event.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2acceleratorkeypressedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2acceleratorkeypressedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is This is a continuation of the ICoreWebView2AcceleratorKeyPressedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2acceleratorkeypressedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2acceleratorkeypressedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `AcceleratorKeyPressed` events.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `AddScriptToExecuteOnDocumentCreated` method.
 title: WebView2 Win32 C++ ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2basicauthenticationrequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2basicauthenticationrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2basicauthenticationrequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2basicauthenticationrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2basicauthenticationresponse.md
+++ b/1-0-2357-prerelease/icorewebview2basicauthenticationresponse.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a Basic HTTP authentication response that contains a user name and a password as according to RFC7617 (https://tools.ietf.org/html/rfc7617)
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationResponse
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2browserextension.md
+++ b/1-0-2357-prerelease/icorewebview2browserextension.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing an Extension, which includes an ID, name, and whether it is enabled or not, and the ability to Remove the Extension, and enable or disable it.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtension
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtension
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2browserextensionenablecompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2browserextensionenablecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of setting the browser Extension as enabled or disabled.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionEnableCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionEnableCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2browserextensionlist.md
+++ b/1-0-2357-prerelease/icorewebview2browserextensionlist.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing browser Extension Lists from user profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionList
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2browserextensionremovecompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2browserextensionremovecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of removing the browser Extension from the Profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionRemoveCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionRemoveCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2browserprocessexitedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2browserprocessexitedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2browserprocessexitedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2browserprocessexitedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `BrowserProcessExited` events.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2bytesreceivedchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2bytesreceivedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `BytesReceivedChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2BytesReceivedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BytesReceivedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `CallDevToolsProtocolMethod` completion results.
 title: WebView2 Win32 C++ ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2capturepreviewcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2capturepreviewcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `CapturePreview` method.
 title: WebView2 Win32 C++ ICoreWebView2CapturePreviewCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CapturePreviewCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2certificate.md
+++ b/1-0-2357-prerelease/icorewebview2certificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2Certificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Certificate
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2clearbrowsingdatacompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2clearbrowsingdatacompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the ClearBrowsingData result.
 title: WebView2 Win32 C++ ICoreWebView2ClearBrowsingDataCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearBrowsingDataCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2clearservercertificateerroractionscompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2clearservercertificateerroractionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ClearServerCertificateErrorActions` method.
 title: WebView2 Win32 C++ ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2clientcertificate.md
+++ b/1-0-2357-prerelease/icorewebview2clientcertificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the client certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificate
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2clientcertificatecollection.md
+++ b/1-0-2357-prerelease/icorewebview2clientcertificatecollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of client certificate object.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateCollection
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2clientcertificaterequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2clientcertificaterequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2clientcertificaterequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2clientcertificaterequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2compositioncontroller.md
+++ b/1-0-2357-prerelease/icorewebview2compositioncontroller.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Controller interface to support visual hosting.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2compositioncontroller2.md
+++ b/1-0-2357-prerelease/icorewebview2compositioncontroller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2CompositionController interface.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2compositioncontroller3.md
+++ b/1-0-2357-prerelease/icorewebview2compositioncontroller3.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is the continuation of the ICoreWebView2CompositionController2 interface to manage drag and drop.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2containsfullscreenelementchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2containsfullscreenelementchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContainsFullScreenElementChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ContainsFullScreenElementChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContainsFullScreenElementChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contentloadingeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2contentloadingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContentLoading` event.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contentloadingeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2contentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contextmenuitem.md
+++ b/1-0-2357-prerelease/icorewebview2contextmenuitem.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a context menu item of a context menu displayed by WebView.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItem
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItem
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contextmenuitemcollection.md
+++ b/1-0-2357-prerelease/icorewebview2contextmenuitemcollection.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a collection of `ContextMenuItem` objects.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItemCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItemCollection
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contextmenurequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2contextmenurequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContextMenuRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contextmenurequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2contextmenurequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContextMenuRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2contextmenutarget.md
+++ b/1-0-2357-prerelease/icorewebview2contextmenutarget.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the information regarding the context menu target.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuTarget
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuTarget
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2controller.md
+++ b/1-0-2357-prerelease/icorewebview2controller.md
@@ -1,7 +1,7 @@
 ---
 description: The owner of the `CoreWebView2` object that provides support for resizing, showing and hiding, focusing, and other functionality related to windowing and composition.
 title: WebView2 Win32 C++ ICoreWebView2Controller
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2controller2.md
+++ b/1-0-2357-prerelease/icorewebview2controller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2controller3.md
+++ b/1-0-2357-prerelease/icorewebview2controller3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2controller4.md
+++ b/1-0-2357-prerelease/icorewebview2controller4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Controller4 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2controlleroptions.md
+++ b/1-0-2357-prerelease/icorewebview2controlleroptions.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to manage profile options that created by 'CreateCoreWebView2ControllerOptions'.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2controlleroptions2.md
+++ b/1-0-2357-prerelease/icorewebview2controlleroptions2.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface in ControllerOptions for ScriptLocale.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2cookie.md
+++ b/1-0-2357-prerelease/icorewebview2cookie.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties that are used to manage an ICoreWebView2Cookie.
 title: WebView2 Win32 C++ ICoreWebView2Cookie
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Cookie
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2cookielist.md
+++ b/1-0-2357-prerelease/icorewebview2cookielist.md
@@ -1,7 +1,7 @@
 ---
 description: A list of cookie objects.
 title: WebView2 Win32 C++ ICoreWebView2CookieList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieList
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2cookiemanager.md
+++ b/1-0-2357-prerelease/icorewebview2cookiemanager.md
@@ -1,7 +1,7 @@
 ---
 description: Creates, adds or updates, gets, or or view the cookies.
 title: WebView2 Win32 C++ ICoreWebView2CookieManager
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieManager
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the CoreWebView2Controller created via CreateCoreWebView2CompositionController.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2createcorewebview2controllercompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2createcorewebview2controllercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Controller` created using `CreateCoreWebView2Controller`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2createcorewebview2environmentcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2createcorewebview2environmentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `WebView2Environment` created using `CreateCoreWebView2Environment`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2cursorchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2cursorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive CursorChanged events.
 title: WebView2 Win32 C++ ICoreWebView2CursorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CursorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2customitemselectedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2customitemselectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Raised to notify the host that the end user selected a custom `ContextMenuItem`.
 title: WebView2 Win32 C++ ICoreWebView2CustomItemSelectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomItemSelectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2customschemeregistration.md
+++ b/1-0-2357-prerelease/icorewebview2customschemeregistration.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the registration of a custom scheme with the CoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2CustomSchemeRegistration
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomSchemeRegistration
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2deferral.md
+++ b/1-0-2357-prerelease/icorewebview2deferral.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to complete deferrals on event args that support getting deferrals using the `GetDeferral` method.
 title: WebView2 Win32 C++ ICoreWebView2Deferral
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Deferral
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DevToolsProtocolEventReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2DevToolsProtocolEventReceivedEventArgs interface that provides the session ID of the target where the event originates from.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DevToolsProtocolEventReceived` events from the WebView.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceiver.md
+++ b/1-0-2357-prerelease/icorewebview2devtoolsprotocoleventreceiver.md
@@ -1,7 +1,7 @@
 ---
 description: A Receiver is created for a particular DevTools Protocol event and allows you to subscribe and unsubscribe from that event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceiver
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceiver
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2documenttitlechangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2documenttitlechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DocumentTitleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2DocumentTitleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DocumentTitleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2domcontentloadedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2domcontentloadedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the DOMContentLoaded event.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2domcontentloadedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2domcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2downloadoperation.md
+++ b/1-0-2357-prerelease/icorewebview2downloadoperation.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a download operation.
 title: WebView2 Win32 C++ ICoreWebView2DownloadOperation
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadOperation
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2downloadstartingeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2downloadstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2downloadstartingeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2downloadstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Add an event handler for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment.md
+++ b/1-0-2357-prerelease/icorewebview2environment.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment10.md
+++ b/1-0-2357-prerelease/icorewebview2environment10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to create ICoreWebView2ControllerOptions object, which can be passed as a parameter in `CreateCoreWebView2ControllerWithOptions` and `CreateCoreWebView2CompositionControllerWithOptions` function for multiple profiles support.
 title: WebView2 Win32 C++ ICoreWebView2Environment10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment10
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment11.md
+++ b/1-0-2357-prerelease/icorewebview2environment11.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting the crash dump folder path.
 title: WebView2 Win32 C++ ICoreWebView2Environment11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment11
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment12.md
+++ b/1-0-2357-prerelease/icorewebview2environment12.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating shared buffer object.
 title: WebView2 Win32 C++ ICoreWebView2Environment12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment12
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment13.md
+++ b/1-0-2357-prerelease/icorewebview2environment13.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting process with associated information.
 title: WebView2 Win32 C++ ICoreWebView2Environment13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment13
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment2.md
+++ b/1-0-2357-prerelease/icorewebview2environment2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment3.md
+++ b/1-0-2357-prerelease/icorewebview2environment3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment4.md
+++ b/1-0-2357-prerelease/icorewebview2environment4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment3 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment5.md
+++ b/1-0-2357-prerelease/icorewebview2environment5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment4 interface that supports the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment6.md
+++ b/1-0-2357-prerelease/icorewebview2environment6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment that supports creating print settings for printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2Environment6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment6
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment7.md
+++ b/1-0-2357-prerelease/icorewebview2environment7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment7
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment8.md
+++ b/1-0-2357-prerelease/icorewebview2environment8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment7 interface that supports the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment8
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environment9.md
+++ b/1-0-2357-prerelease/icorewebview2environment9.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating CoreWebView2 ContextMenuItem objects.
 title: WebView2 Win32 C++ ICoreWebView2Environment9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment9
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environmentoptions.md
+++ b/1-0-2357-prerelease/icorewebview2environmentoptions.md
@@ -1,7 +1,7 @@
 ---
 description: Options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environmentoptions2.md
+++ b/1-0-2357-prerelease/icorewebview2environmentoptions2.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environmentoptions3.md
+++ b/1-0-2357-prerelease/icorewebview2environmentoptions3.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage crash reporting.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environmentoptions4.md
+++ b/1-0-2357-prerelease/icorewebview2environmentoptions4.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment that manages custom scheme registration.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environmentoptions5.md
+++ b/1-0-2357-prerelease/icorewebview2environmentoptions5.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2environmentoptions6.md
+++ b/1-0-2357-prerelease/icorewebview2environmentoptions6.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions6
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2estimatedendtimechangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2estimatedendtimechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `EstimatedEndTimeChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2EstimatedEndTimeChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EstimatedEndTimeChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2executescriptcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2executescriptcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ExecuteScript` method.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2executescriptresult.md
+++ b/1-0-2357-prerelease/icorewebview2executescriptresult.md
@@ -1,7 +1,7 @@
 ---
 description: This is the result for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptResult
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptResult
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2executescriptwithresultcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2executescriptwithresultcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptWithResultCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptWithResultCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimental20.md
+++ b/1-0-2357-prerelease/icorewebview2experimental20.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2 experimental interface for custom data partition.
 title: WebView2 Win32 C++ ICoreWebView2Experimental20
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Experimental20
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimental22.md
+++ b/1-0-2357-prerelease/icorewebview2experimental22.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Experimental22 interface that manages WebView2 Web Notification functionality.
 title: WebView2 Win32 C++ ICoreWebView2Experimental22
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Experimental22
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalclearcustomdatapartitioncompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalclearcustomdatapartitioncompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the ClearCustomDataPartition result.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalClearCustomDataPartitionCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalClearCustomDataPartitionCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalcompositioncontroller4.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalcompositioncontroller4.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2CompositionController.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalCompositionController4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalCompositionController4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalcompositioncontroller5.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalcompositioncontroller5.md
@@ -1,7 +1,7 @@
 ---
 description: This Interface includes an API which enables non-client hit-testing support for WebView2.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalCompositionController5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalCompositionController5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalenvironment12.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalenvironment12.md
@@ -1,7 +1,7 @@
 ---
 description: This is ICoreWebView2ExperimentalEnvironment12 that returns the texture stream interface.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalEnvironment12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalEnvironment12
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalenvironment3.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalenvironment3.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment that manages updating Edge WebView2 Runtime.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalEnvironment3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalEnvironment3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalenvironmentoptions.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalenvironmentoptions.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create the WebView2 Environment that support specifying the `ReleaseChannels` and `ChannelSearchKind`.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalEnvironmentOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalEnvironmentOptions
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalnonclientregionchangedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalnonclientregionchangedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: This is the Interface for non-client region change event args.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNonClientRegionChangedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNonClientRegionChangedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalnonclientregionchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalnonclientregionchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the Interface of the event handler for the non-client region changed event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNonClientRegionChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNonClientRegionChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalnotification.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalnotification.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2ExperimentalNotification that represents a HTML Notification object.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotification
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotification
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalnotificationcloserequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalnotificationcloserequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `CloseRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotificationCloseRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotificationCloseRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalnotificationreceivedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalnotificationreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NotificationReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotificationReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotificationReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalnotificationreceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalnotificationreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `NotificationReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotificationReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotificationReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalprocessfailedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalprocessfailedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2ProcessFailedEventArgs2 interface fot getting blocked file for code integrity process failures.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalProcessFailedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalProcessFailedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalprofile7.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalprofile7.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2 experimental profile interface.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalProfile7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalProfile7
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalregionrectcollectionview.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalregionrectcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: This Interface Represents a Collection of Region Rects.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalRegionRectCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalRegionRectCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalrenderadapterluidchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalrenderadapterluidchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for the browser process's display LUID change.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalRenderAdapterLUIDChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalRenderAdapterLUIDChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalsettings8.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalsettings8.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Settings Experimental Interface.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalSettings8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalSettings8
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexture.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexture.md
@@ -1,7 +1,7 @@
 ---
 description: texture that the host writes to so that the Renderer will render on it.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTexture
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTexture
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestream.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestream.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface that handles texture streaming.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStream
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStream
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: The event args for the `ICoreWebViewTextureStream ErrorReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamErrorReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamErrorReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for texture stream rendering error.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamErrorReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamErrorReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamstartrequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamstartrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for new texture stream request.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamStartRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamStartRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamstoppedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamstoppedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for stop request of texture stream.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamStoppedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamStoppedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: The event args for the `ICoreWebView2TextureStream WebTextureReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for web texture.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentaltexturestreamwebtexturestreamstoppedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentaltexturestreamwebtexturestreamstoppedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for web texture stop.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamWebTextureStreamStoppedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamWebTextureStreamStoppedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalupdateruntimecompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalupdateruntimecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the UpdateRuntime result.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalUpdateRuntimeCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalUpdateRuntimeCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalupdateruntimeresult.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalupdateruntimeresult.md
@@ -1,7 +1,7 @@
 ---
 description: The UpdateRuntime operation result.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalUpdateRuntimeResult
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalUpdateRuntimeResult
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2experimentalwebtexture.md
+++ b/1-0-2357-prerelease/icorewebview2experimentalwebtexture.md
@@ -1,7 +1,7 @@
 ---
 description: Received texture that the renderer writes to so that the host will read on it.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalWebTexture
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalWebTexture
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2faviconchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2faviconchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for when the `Favicon` is changed.
 title: WebView2 Win32 C++ ICoreWebView2FaviconChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FaviconChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2file.md
+++ b/1-0-2357-prerelease/icorewebview2file.md
@@ -1,7 +1,7 @@
 ---
 description: Representation of a DOM File object passed via WebMessage.
 title: WebView2 Win32 C++ ICoreWebView2File
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2File
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2focuschangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2focuschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `GotFocus` and `LostFocus` events.
 title: WebView2 Win32 C++ ICoreWebView2FocusChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FocusChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frame.md
+++ b/1-0-2357-prerelease/icorewebview2frame.md
@@ -1,7 +1,7 @@
 ---
 description: ICoreWebView2Frame provides direct access to the iframes information.
 title: WebView2 Win32 C++ ICoreWebView2Frame
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frame2.md
+++ b/1-0-2357-prerelease/icorewebview2frame2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Frame interface with navigation events, executing script and posting web messages.
 title: WebView2 Win32 C++ ICoreWebView2Frame2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frame3.md
+++ b/1-0-2357-prerelease/icorewebview2frame3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports PermissionRequested.
 title: WebView2 Win32 C++ ICoreWebView2Frame3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frame4.md
+++ b/1-0-2357-prerelease/icorewebview2frame4.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2Frame4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frame5.md
+++ b/1-0-2357-prerelease/icorewebview2frame5.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2Frame5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framecontentloadingeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framecontentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framecreatedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2framecreatedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `FrameCreated` events.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framecreatedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framecreatedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameCreated` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framedestroyedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framedestroyedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameDestroyed` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameDestroyedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDestroyedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framedomcontentloadedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framedomcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameDOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frameinfo.md
+++ b/1-0-2357-prerelease/icorewebview2frameinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a frame in the ICoreWebView2.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frameinfo2.md
+++ b/1-0-2357-prerelease/icorewebview2frameinfo2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2FrameInfo interface that provides `ParentFrameInfo`, `FrameId` and `FrameKind` properties.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frameinfocollection.md
+++ b/1-0-2357-prerelease/icorewebview2frameinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: Collection of `FrameInfo`s (name and source).
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2frameinfocollectioniterator.md
+++ b/1-0-2357-prerelease/icorewebview2frameinfocollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of `FrameInfo`s.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framenamechangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framenamechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameNameChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameNameChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNameChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framenavigationcompletedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framenavigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framenavigationstartingeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framenavigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framepermissionrequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framepermissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events for iframes.
 title: WebView2 Win32 C++ ICoreWebView2FramePermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FramePermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2framewebmessagereceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2framewebmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameWebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameWebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2getcookiescompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2getcookiescompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetCookies` method.
 title: WebView2 Win32 C++ ICoreWebView2GetCookiesCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetCookiesCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2getfaviconcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2getfaviconcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for the completion of the population of `imageStream`.
 title: WebView2 Win32 C++ ICoreWebView2GetFaviconCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetFaviconCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `GetNonDefaultPermissionSettings`.
 title: WebView2 Win32 C++ ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2getprocessextendedinfoscompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2getprocessextendedinfoscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetProcessExtendedInfos` method.
 title: WebView2 Win32 C++ ICoreWebView2GetProcessExtendedInfosCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetProcessExtendedInfosCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2historychangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2historychangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `HistoryChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2HistoryChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HistoryChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2httpheaderscollectioniterator.md
+++ b/1-0-2357-prerelease/icorewebview2httpheaderscollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of HTTP headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpHeadersCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpHeadersCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2httprequestheaders.md
+++ b/1-0-2357-prerelease/icorewebview2httprequestheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP request headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpRequestHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpRequestHeaders
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2httpresponseheaders.md
+++ b/1-0-2357-prerelease/icorewebview2httpresponseheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP response headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpResponseHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpResponseHeaders
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDefaultDownloadDialogOpenChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2isdocumentplayingaudiochangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2isdocumentplayingaudiochangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDocumentPlayingAudioChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2ismutedchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2ismutedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsMutedChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsMutedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsMutedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2launchingexternalurischemeeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2launchingexternalurischemeeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2launchingexternalurischemeeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2launchingexternalurischemeeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Event handler for the `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2movefocusrequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2movefocusrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `MoveFocusRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2movefocusrequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2movefocusrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `MoveFocusRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationcompletedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2navigationcompletedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationCompleted` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationcompletedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2navigationcompletedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is an interface for the StatusCode property of ICoreWebView2NavigationCompletedEventArgs.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationcompletedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2navigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationstartingeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2navigationstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationstartingeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2navigationstartingeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: The AdditionalAllowedFrameAncestors API that enable developers to provide additional allowed frame ancestors.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationstartingeventargs3.md
+++ b/1-0-2357-prerelease/icorewebview2navigationstartingeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: The NavigationKind API that enables developers to get more information about navigation type.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2navigationstartingeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2navigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2newbrowserversionavailableeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2newbrowserversionavailableeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewBrowserVersionAvailable` events.
 title: WebView2 Win32 C++ ICoreWebView2NewBrowserVersionAvailableEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewBrowserVersionAvailableEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2newwindowrequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2newwindowrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NewWindowRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2newwindowrequestedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2newwindowrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2newwindowrequestedeventargs3.md
+++ b/1-0-2357-prerelease/icorewebview2newwindowrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2newwindowrequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2newwindowrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewWindowRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2objectcollectionview.md
+++ b/1-0-2357-prerelease/icorewebview2objectcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of generic objects.
 title: WebView2 Win32 C++ ICoreWebView2ObjectCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ObjectCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2permissionrequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2permissionrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `PermissionRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2permissionrequestedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2permissionrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2permissionrequestedeventargs3.md
+++ b/1-0-2357-prerelease/icorewebview2permissionrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs2 interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2permissionrequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2permissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2permissionsetting.md
+++ b/1-0-2357-prerelease/icorewebview2permissionsetting.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a permission setting.
 title: WebView2 Win32 C++ ICoreWebView2PermissionSetting
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSetting
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2permissionsettingcollectionview.md
+++ b/1-0-2357-prerelease/icorewebview2permissionsettingcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of `PermissionSetting`s (origin, kind, and state).
 title: WebView2 Win32 C++ ICoreWebView2PermissionSettingCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSettingCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2pointerinfo.md
+++ b/1-0-2357-prerelease/icorewebview2pointerinfo.md
@@ -1,7 +1,7 @@
 ---
 description: This mostly represents a combined win32 POINTER_INFO/POINTER_TOUCH_INFO/POINTER_PEN_INFO object.
 title: WebView2 Win32 C++ ICoreWebView2PointerInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PointerInfo
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2printcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2printcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2printsettings.md
+++ b/1-0-2357-prerelease/icorewebview2printsettings.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2printsettings2.md
+++ b/1-0-2357-prerelease/icorewebview2printsettings2.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2printtopdfcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2printtopdfcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2printtopdfstreamcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2printtopdfstreamcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdfStream` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfStreamCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfStreamCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processextendedinfo.md
+++ b/1-0-2357-prerelease/icorewebview2processextendedinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides process with associated extended information in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfo
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processextendedinfocollection.md
+++ b/1-0-2357-prerelease/icorewebview2processextendedinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing processInfo and associated extended information.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processfailedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2processfailedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ProcessFailed` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processfailedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2processfailedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2ProcessFailedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processfailedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2processfailedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ProcessFailed` events.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processinfo.md
+++ b/1-0-2357-prerelease/icorewebview2processinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a process in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfo
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processinfocollection.md
+++ b/1-0-2357-prerelease/icorewebview2processinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing process id and corresponding process type.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2processinfoschangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2processinfoschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfosChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfosChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile.md
+++ b/1-0-2357-prerelease/icorewebview2profile.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties to configure a Profile object.
 title: WebView2 Win32 C++ ICoreWebView2Profile
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile2.md
+++ b/1-0-2357-prerelease/icorewebview2profile2.md
@@ -1,7 +1,7 @@
 ---
 description: Profile2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Profile2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile3.md
+++ b/1-0-2357-prerelease/icorewebview2profile3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Profile interface to control levels of tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2Profile3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile4.md
+++ b/1-0-2357-prerelease/icorewebview2profile4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for the permission management APIs.
 title: WebView2 Win32 C++ ICoreWebView2Profile4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile5.md
+++ b/1-0-2357-prerelease/icorewebview2profile5.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for cookie manager.
 title: WebView2 Win32 C++ ICoreWebView2Profile5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile6.md
+++ b/1-0-2357-prerelease/icorewebview2profile6.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing password-autosave and general-autofill.
 title: WebView2 Win32 C++ ICoreWebView2Profile6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile6
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile7.md
+++ b/1-0-2357-prerelease/icorewebview2profile7.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2Profile7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile7
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profile8.md
+++ b/1-0-2357-prerelease/icorewebview2profile8.md
@@ -1,7 +1,7 @@
 ---
 description: This is the profile interface that manages profile deletion.
 title: WebView2 Win32 C++ ICoreWebView2Profile8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile8
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profileaddbrowserextensioncompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2profileaddbrowserextensioncompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of loading an browser Extension.
 title: WebView2 Win32 C++ ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profiledeletedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2profiledeletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Profile.Deleted` event.
 title: WebView2 Win32 C++ ICoreWebView2ProfileDeletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileDeletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2profilegetbrowserextensionscompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2profilegetbrowserextensionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of getting the browser Extensions.
 title: WebView2 Win32 C++ ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2rasterizationscalechangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2rasterizationscalechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `RasterizationScaleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2RasterizationScaleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2RasterizationScaleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2scriptdialogopeningeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2scriptdialogopeningeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ScriptDialogOpening` event.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2scriptdialogopeningeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2scriptdialogopeningeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ScriptDialogOpening` events.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2scriptexception.md
+++ b/1-0-2357-prerelease/icorewebview2scriptexception.md
@@ -1,7 +1,7 @@
 ---
 description: This interface represents a JavaScript exception.
 title: WebView2 Win32 C++ ICoreWebView2ScriptException
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptException
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2servercertificateerrordetectedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2servercertificateerrordetectedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2servercertificateerrordetectedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2servercertificateerrordetectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2setpermissionstatecompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2setpermissionstatecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `SetPermissionState`.
 title: WebView2 Win32 C++ ICoreWebView2SetPermissionStateCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SetPermissionStateCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings.md
+++ b/1-0-2357-prerelease/icorewebview2settings.md
@@ -1,7 +1,7 @@
 ---
 description: Defines properties that enable, disable, or modify WebView features.
 title: WebView2 Win32 C++ ICoreWebView2Settings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings2.md
+++ b/1-0-2357-prerelease/icorewebview2settings2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages the user agent.
 title: WebView2 Win32 C++ ICoreWebView2Settings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings3.md
+++ b/1-0-2357-prerelease/icorewebview2settings3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages whether browser accelerator keys are enabled.
 title: WebView2 Win32 C++ ICoreWebView2Settings3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings3
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings4.md
+++ b/1-0-2357-prerelease/icorewebview2settings4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage autofill.
 title: WebView2 Win32 C++ ICoreWebView2Settings4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings4
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings5.md
+++ b/1-0-2357-prerelease/icorewebview2settings5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage pinch zoom.
 title: WebView2 Win32 C++ ICoreWebView2Settings5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings5
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings6.md
+++ b/1-0-2357-prerelease/icorewebview2settings6.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage swipe navigation.
 title: WebView2 Win32 C++ ICoreWebView2Settings6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings6
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings7.md
+++ b/1-0-2357-prerelease/icorewebview2settings7.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to hide Pdf toolbar items.
 title: WebView2 Win32 C++ ICoreWebView2Settings7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings7
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2settings8.md
+++ b/1-0-2357-prerelease/icorewebview2settings8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage smartscreen.
 title: WebView2 Win32 C++ ICoreWebView2Settings8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings8
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2sharedbuffer.md
+++ b/1-0-2357-prerelease/icorewebview2sharedbuffer.md
@@ -1,7 +1,7 @@
 ---
 description: The shared buffer object that is created by CreateSharedBuffer.
 title: WebView2 Win32 C++ ICoreWebView2SharedBuffer
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SharedBuffer
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2sourcechangedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2sourcechangedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `SourceChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2sourcechangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2sourcechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `SourceChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2statechangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2statechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `StateChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2StateChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StateChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2statusbartextchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2statusbartextchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `StatusBarTextChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2StatusBarTextChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StatusBarTextChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2stringcollection.md
+++ b/1-0-2357-prerelease/icorewebview2stringcollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of strings.
 title: WebView2 Win32 C++ ICoreWebView2StringCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StringCollection
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2trysuspendcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2trysuspendcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the TrySuspend result.
 title: WebView2 Win32 C++ ICoreWebView2TrySuspendCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2TrySuspendCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webmessagereceivedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2webmessagereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebMessageReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webmessagereceivedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2webmessagereceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Extension of WebMessageReceivedEventArgs to provide access to additional WebMessage objects.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webmessagereceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2webmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourcerequest.md
+++ b/1-0-2357-prerelease/icorewebview2webresourcerequest.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP request used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequest
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequest
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourcerequestedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2webresourcerequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourcerequestedeventargs2.md
+++ b/1-0-2357-prerelease/icorewebview2webresourcerequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourcerequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2webresourcerequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Runs when a URL request (through network, file, and so on) is made in the webview for a Web resource matching resource context filter and URL specified in `AddWebResourceRequestedFilter`.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourceresponse.md
+++ b/1-0-2357-prerelease/icorewebview2webresourceresponse.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP response used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponse
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourceresponsereceivedeventargs.md
+++ b/1-0-2357-prerelease/icorewebview2webresourceresponsereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the WebResourceResponseReceived event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourceresponsereceivedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2webresourceresponsereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebResourceResponseReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourceresponseview.md
+++ b/1-0-2357-prerelease/icorewebview2webresourceresponseview.md
@@ -1,7 +1,7 @@
 ---
 description: View of the HTTP representation for a web resource response.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseView
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
+++ b/1-0-2357-prerelease/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the ICoreWebView2WebResourceResponseView::GetContent method.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2windowcloserequestedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2windowcloserequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WindowCloseRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2WindowCloseRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowCloseRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2windowfeatures.md
+++ b/1-0-2357-prerelease/icorewebview2windowfeatures.md
@@ -1,7 +1,7 @@
 ---
 description: The window features for a WebView popup window.
 title: WebView2 Win32 C++ ICoreWebView2WindowFeatures
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowFeatures
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/icorewebview2zoomfactorchangedeventhandler.md
+++ b/1-0-2357-prerelease/icorewebview2zoomfactorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `ZoomFactorChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ZoomFactorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ZoomFactorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/index.md
+++ b/1-0-2357-prerelease/index.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 C++ Reference
 title: WebView2 Win32 C++ Reference
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 ---
 

--- a/1-0-2357-prerelease/webview2-idl.md
+++ b/1-0-2357-prerelease/webview2-idl.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 Globals
 title: Globals
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 topic_type: 
 - APIRef

--- a/1-0-2357-prerelease/webview2experimental-idl.md
+++ b/1-0-2357-prerelease/webview2experimental-idl.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 Experimental Globals
 title: Experimental Globals
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2.md
+++ b/1-0-2365-46/icorewebview2.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 enables you to host web content using the latest Microsoft Edge browser and web technology.
 title: WebView2 Win32 C++ ICoreWebView2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_10.md
+++ b/1-0-2365-46/icorewebview2_10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_9 that supports BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_10
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_11.md
+++ b/1-0-2365-46/icorewebview2_11.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_10 that supports sessionId for CDP method calls and ContextMenuRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_11
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_12.md
+++ b/1-0-2365-46/icorewebview2_12.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_11 that supports StatusBarTextChanged event.
 title: WebView2 Win32 C++ ICoreWebView2_12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_12
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_13.md
+++ b/1-0-2365-46/icorewebview2_13.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_12 that supports Profile API.
 title: WebView2 Win32 C++ ICoreWebView2_13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_13
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_14.md
+++ b/1-0-2365-46/icorewebview2_14.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_13 that adds ServerCertificate support.
 title: WebView2 Win32 C++ ICoreWebView2_14
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_14
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_15.md
+++ b/1-0-2365-46/icorewebview2_15.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_14 that supports status Favicons.
 title: WebView2 Win32 C++ ICoreWebView2_15
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_15
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_16.md
+++ b/1-0-2365-46/icorewebview2_16.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface to support printing.
 title: WebView2 Win32 C++ ICoreWebView2_16
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_16
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_17.md
+++ b/1-0-2365-46/icorewebview2_17.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_16 that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2_17
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_17
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_18.md
+++ b/1-0-2365-46/icorewebview2_18.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_17 that manages navigation requests to URI schemes registered with the OS.
 title: WebView2 Win32 C++ ICoreWebView2_18
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_18
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_19.md
+++ b/1-0-2365-46/icorewebview2_19.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_18 that manages memory usage target level.
 title: WebView2 Win32 C++ ICoreWebView2_19
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_19
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_2.md
+++ b/1-0-2365-46/icorewebview2_2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_20.md
+++ b/1-0-2365-46/icorewebview2_20.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_19 that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2_20
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_20
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_21.md
+++ b/1-0-2365-46/icorewebview2_21.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface for getting string and exception with ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2_21
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_21
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_22.md
+++ b/1-0-2365-46/icorewebview2_22.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2 that allows to set filters in order to receive WebResourceRequested events for service workers, shared workers and different origin iframes.
 title: WebView2 Win32 C++ ICoreWebView2_22
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_22
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_3.md
+++ b/1-0-2365-46/icorewebview2_3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_4.md
+++ b/1-0-2365-46/icorewebview2_4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_3 interface to support FrameCreated and DownloadStarting events.
 title: WebView2 Win32 C++ ICoreWebView2_4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_5.md
+++ b/1-0-2365-46/icorewebview2_5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_4 interface to support ClientCertificateRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_5
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_6.md
+++ b/1-0-2365-46/icorewebview2_6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_5 that manages opening the browser task manager window.
 title: WebView2 Win32 C++ ICoreWebView2_6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_6
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_7.md
+++ b/1-0-2365-46/icorewebview2_7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_6 that supports printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2_7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_7
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_8.md
+++ b/1-0-2365-46/icorewebview2_8.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_7 that supports media features.
 title: WebView2 Win32 C++ ICoreWebView2_8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_8
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2_9.md
+++ b/1-0-2365-46/icorewebview2_9.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_8 that default download dialog positioning and anchoring.
 title: WebView2 Win32 C++ ICoreWebView2_9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_9
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2acceleratorkeypressedeventargs.md
+++ b/1-0-2365-46/icorewebview2acceleratorkeypressedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `AcceleratorKeyPressed` event.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2acceleratorkeypressedeventargs2.md
+++ b/1-0-2365-46/icorewebview2acceleratorkeypressedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is This is a continuation of the ICoreWebView2AcceleratorKeyPressedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2acceleratorkeypressedeventhandler.md
+++ b/1-0-2365-46/icorewebview2acceleratorkeypressedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `AcceleratorKeyPressed` events.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `AddScriptToExecuteOnDocumentCreated` method.
 title: WebView2 Win32 C++ ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2basicauthenticationrequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2basicauthenticationrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2basicauthenticationrequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2basicauthenticationrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2basicauthenticationresponse.md
+++ b/1-0-2365-46/icorewebview2basicauthenticationresponse.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a Basic HTTP authentication response that contains a user name and a password as according to RFC7617 (https://tools.ietf.org/html/rfc7617)
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationResponse
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2browserextension.md
+++ b/1-0-2365-46/icorewebview2browserextension.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing an Extension, which includes an ID, name, and whether it is enabled or not, and the ability to Remove the Extension, and enable or disable it.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtension
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtension
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2browserextensionenablecompletedhandler.md
+++ b/1-0-2365-46/icorewebview2browserextensionenablecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of setting the browser Extension as enabled or disabled.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionEnableCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionEnableCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2browserextensionlist.md
+++ b/1-0-2365-46/icorewebview2browserextensionlist.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing browser Extension Lists from user profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionList
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2browserextensionremovecompletedhandler.md
+++ b/1-0-2365-46/icorewebview2browserextensionremovecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of removing the browser Extension from the Profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionRemoveCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionRemoveCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2browserprocessexitedeventargs.md
+++ b/1-0-2365-46/icorewebview2browserprocessexitedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2browserprocessexitedeventhandler.md
+++ b/1-0-2365-46/icorewebview2browserprocessexitedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `BrowserProcessExited` events.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2bytesreceivedchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2bytesreceivedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `BytesReceivedChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2BytesReceivedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BytesReceivedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `CallDevToolsProtocolMethod` completion results.
 title: WebView2 Win32 C++ ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2capturepreviewcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2capturepreviewcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `CapturePreview` method.
 title: WebView2 Win32 C++ ICoreWebView2CapturePreviewCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CapturePreviewCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2certificate.md
+++ b/1-0-2365-46/icorewebview2certificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2Certificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Certificate
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2clearbrowsingdatacompletedhandler.md
+++ b/1-0-2365-46/icorewebview2clearbrowsingdatacompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the ClearBrowsingData result.
 title: WebView2 Win32 C++ ICoreWebView2ClearBrowsingDataCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearBrowsingDataCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2clearservercertificateerroractionscompletedhandler.md
+++ b/1-0-2365-46/icorewebview2clearservercertificateerroractionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ClearServerCertificateErrorActions` method.
 title: WebView2 Win32 C++ ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2clientcertificate.md
+++ b/1-0-2365-46/icorewebview2clientcertificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the client certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificate
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2clientcertificatecollection.md
+++ b/1-0-2365-46/icorewebview2clientcertificatecollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of client certificate object.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateCollection
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2clientcertificaterequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2clientcertificaterequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2clientcertificaterequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2clientcertificaterequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2compositioncontroller.md
+++ b/1-0-2365-46/icorewebview2compositioncontroller.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Controller interface to support visual hosting.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2compositioncontroller2.md
+++ b/1-0-2365-46/icorewebview2compositioncontroller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2CompositionController interface.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2compositioncontroller3.md
+++ b/1-0-2365-46/icorewebview2compositioncontroller3.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is the continuation of the ICoreWebView2CompositionController2 interface to manage drag and drop.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2containsfullscreenelementchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2containsfullscreenelementchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContainsFullScreenElementChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ContainsFullScreenElementChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContainsFullScreenElementChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contentloadingeventargs.md
+++ b/1-0-2365-46/icorewebview2contentloadingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContentLoading` event.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contentloadingeventhandler.md
+++ b/1-0-2365-46/icorewebview2contentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contextmenuitem.md
+++ b/1-0-2365-46/icorewebview2contextmenuitem.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a context menu item of a context menu displayed by WebView.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItem
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItem
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contextmenuitemcollection.md
+++ b/1-0-2365-46/icorewebview2contextmenuitemcollection.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a collection of `ContextMenuItem` objects.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItemCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItemCollection
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contextmenurequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2contextmenurequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContextMenuRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contextmenurequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2contextmenurequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContextMenuRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2contextmenutarget.md
+++ b/1-0-2365-46/icorewebview2contextmenutarget.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the information regarding the context menu target.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuTarget
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuTarget
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2controller.md
+++ b/1-0-2365-46/icorewebview2controller.md
@@ -1,7 +1,7 @@
 ---
 description: The owner of the `CoreWebView2` object that provides support for resizing, showing and hiding, focusing, and other functionality related to windowing and composition.
 title: WebView2 Win32 C++ ICoreWebView2Controller
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2controller2.md
+++ b/1-0-2365-46/icorewebview2controller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2controller3.md
+++ b/1-0-2365-46/icorewebview2controller3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2controller4.md
+++ b/1-0-2365-46/icorewebview2controller4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Controller4 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2controlleroptions.md
+++ b/1-0-2365-46/icorewebview2controlleroptions.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to manage profile options that created by 'CreateCoreWebView2ControllerOptions'.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2controlleroptions2.md
+++ b/1-0-2365-46/icorewebview2controlleroptions2.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface in ControllerOptions for ScriptLocale.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2cookie.md
+++ b/1-0-2365-46/icorewebview2cookie.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties that are used to manage an ICoreWebView2Cookie.
 title: WebView2 Win32 C++ ICoreWebView2Cookie
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Cookie
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2cookielist.md
+++ b/1-0-2365-46/icorewebview2cookielist.md
@@ -1,7 +1,7 @@
 ---
 description: A list of cookie objects.
 title: WebView2 Win32 C++ ICoreWebView2CookieList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieList
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2cookiemanager.md
+++ b/1-0-2365-46/icorewebview2cookiemanager.md
@@ -1,7 +1,7 @@
 ---
 description: Creates, adds or updates, gets, or or view the cookies.
 title: WebView2 Win32 C++ ICoreWebView2CookieManager
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieManager
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
+++ b/1-0-2365-46/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the CoreWebView2Controller created via CreateCoreWebView2CompositionController.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2createcorewebview2controllercompletedhandler.md
+++ b/1-0-2365-46/icorewebview2createcorewebview2controllercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Controller` created using `CreateCoreWebView2Controller`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2createcorewebview2environmentcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2createcorewebview2environmentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `WebView2Environment` created using `CreateCoreWebView2Environment`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2cursorchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2cursorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive CursorChanged events.
 title: WebView2 Win32 C++ ICoreWebView2CursorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CursorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2customitemselectedeventhandler.md
+++ b/1-0-2365-46/icorewebview2customitemselectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Raised to notify the host that the end user selected a custom `ContextMenuItem`.
 title: WebView2 Win32 C++ ICoreWebView2CustomItemSelectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomItemSelectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2customschemeregistration.md
+++ b/1-0-2365-46/icorewebview2customschemeregistration.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the registration of a custom scheme with the CoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2CustomSchemeRegistration
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomSchemeRegistration
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2deferral.md
+++ b/1-0-2365-46/icorewebview2deferral.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to complete deferrals on event args that support getting deferrals using the `GetDeferral` method.
 title: WebView2 Win32 C++ ICoreWebView2Deferral
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Deferral
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2devtoolsprotocoleventreceivedeventargs.md
+++ b/1-0-2365-46/icorewebview2devtoolsprotocoleventreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DevToolsProtocolEventReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
+++ b/1-0-2365-46/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2DevToolsProtocolEventReceivedEventArgs interface that provides the session ID of the target where the event originates from.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
+++ b/1-0-2365-46/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DevToolsProtocolEventReceived` events from the WebView.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2devtoolsprotocoleventreceiver.md
+++ b/1-0-2365-46/icorewebview2devtoolsprotocoleventreceiver.md
@@ -1,7 +1,7 @@
 ---
 description: A Receiver is created for a particular DevTools Protocol event and allows you to subscribe and unsubscribe from that event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceiver
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceiver
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2documenttitlechangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2documenttitlechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DocumentTitleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2DocumentTitleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DocumentTitleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2domcontentloadedeventargs.md
+++ b/1-0-2365-46/icorewebview2domcontentloadedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the DOMContentLoaded event.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2domcontentloadedeventhandler.md
+++ b/1-0-2365-46/icorewebview2domcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2downloadoperation.md
+++ b/1-0-2365-46/icorewebview2downloadoperation.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a download operation.
 title: WebView2 Win32 C++ ICoreWebView2DownloadOperation
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadOperation
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2downloadstartingeventargs.md
+++ b/1-0-2365-46/icorewebview2downloadstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2downloadstartingeventhandler.md
+++ b/1-0-2365-46/icorewebview2downloadstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Add an event handler for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment.md
+++ b/1-0-2365-46/icorewebview2environment.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment10.md
+++ b/1-0-2365-46/icorewebview2environment10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to create ICoreWebView2ControllerOptions object, which can be passed as a parameter in `CreateCoreWebView2ControllerWithOptions` and `CreateCoreWebView2CompositionControllerWithOptions` function for multiple profiles support.
 title: WebView2 Win32 C++ ICoreWebView2Environment10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment10
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment11.md
+++ b/1-0-2365-46/icorewebview2environment11.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting the crash dump folder path.
 title: WebView2 Win32 C++ ICoreWebView2Environment11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment11
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment12.md
+++ b/1-0-2365-46/icorewebview2environment12.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating shared buffer object.
 title: WebView2 Win32 C++ ICoreWebView2Environment12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment12
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment13.md
+++ b/1-0-2365-46/icorewebview2environment13.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting process with associated information.
 title: WebView2 Win32 C++ ICoreWebView2Environment13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment13
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment2.md
+++ b/1-0-2365-46/icorewebview2environment2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment3.md
+++ b/1-0-2365-46/icorewebview2environment3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment4.md
+++ b/1-0-2365-46/icorewebview2environment4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment3 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment5.md
+++ b/1-0-2365-46/icorewebview2environment5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment4 interface that supports the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment5
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment6.md
+++ b/1-0-2365-46/icorewebview2environment6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment that supports creating print settings for printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2Environment6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment6
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment7.md
+++ b/1-0-2365-46/icorewebview2environment7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment7
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment8.md
+++ b/1-0-2365-46/icorewebview2environment8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment7 interface that supports the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment8
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environment9.md
+++ b/1-0-2365-46/icorewebview2environment9.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating CoreWebView2 ContextMenuItem objects.
 title: WebView2 Win32 C++ ICoreWebView2Environment9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment9
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environmentoptions.md
+++ b/1-0-2365-46/icorewebview2environmentoptions.md
@@ -1,7 +1,7 @@
 ---
 description: Options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environmentoptions2.md
+++ b/1-0-2365-46/icorewebview2environmentoptions2.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environmentoptions3.md
+++ b/1-0-2365-46/icorewebview2environmentoptions3.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage crash reporting.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environmentoptions4.md
+++ b/1-0-2365-46/icorewebview2environmentoptions4.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment that manages custom scheme registration.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environmentoptions5.md
+++ b/1-0-2365-46/icorewebview2environmentoptions5.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions5
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2environmentoptions6.md
+++ b/1-0-2365-46/icorewebview2environmentoptions6.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions6
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2estimatedendtimechangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2estimatedendtimechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `EstimatedEndTimeChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2EstimatedEndTimeChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EstimatedEndTimeChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2executescriptcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2executescriptcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ExecuteScript` method.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2executescriptresult.md
+++ b/1-0-2365-46/icorewebview2executescriptresult.md
@@ -1,7 +1,7 @@
 ---
 description: This is the result for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptResult
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptResult
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2executescriptwithresultcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2executescriptwithresultcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptWithResultCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptWithResultCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2faviconchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2faviconchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for when the `Favicon` is changed.
 title: WebView2 Win32 C++ ICoreWebView2FaviconChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FaviconChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2file.md
+++ b/1-0-2365-46/icorewebview2file.md
@@ -1,7 +1,7 @@
 ---
 description: Representation of a DOM File object passed via WebMessage.
 title: WebView2 Win32 C++ ICoreWebView2File
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2File
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2focuschangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2focuschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `GotFocus` and `LostFocus` events.
 title: WebView2 Win32 C++ ICoreWebView2FocusChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FocusChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frame.md
+++ b/1-0-2365-46/icorewebview2frame.md
@@ -1,7 +1,7 @@
 ---
 description: ICoreWebView2Frame provides direct access to the iframes information.
 title: WebView2 Win32 C++ ICoreWebView2Frame
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frame2.md
+++ b/1-0-2365-46/icorewebview2frame2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Frame interface with navigation events, executing script and posting web messages.
 title: WebView2 Win32 C++ ICoreWebView2Frame2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frame3.md
+++ b/1-0-2365-46/icorewebview2frame3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports PermissionRequested.
 title: WebView2 Win32 C++ ICoreWebView2Frame3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frame4.md
+++ b/1-0-2365-46/icorewebview2frame4.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2Frame4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frame5.md
+++ b/1-0-2365-46/icorewebview2frame5.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2Frame5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame5
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framecontentloadingeventhandler.md
+++ b/1-0-2365-46/icorewebview2framecontentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framecreatedeventargs.md
+++ b/1-0-2365-46/icorewebview2framecreatedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `FrameCreated` events.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framecreatedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framecreatedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameCreated` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framedestroyedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framedestroyedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameDestroyed` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameDestroyedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDestroyedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framedomcontentloadedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framedomcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameDOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frameinfo.md
+++ b/1-0-2365-46/icorewebview2frameinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a frame in the ICoreWebView2.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frameinfo2.md
+++ b/1-0-2365-46/icorewebview2frameinfo2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2FrameInfo interface that provides `ParentFrameInfo`, `FrameId` and `FrameKind` properties.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frameinfocollection.md
+++ b/1-0-2365-46/icorewebview2frameinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: Collection of `FrameInfo`s (name and source).
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2frameinfocollectioniterator.md
+++ b/1-0-2365-46/icorewebview2frameinfocollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of `FrameInfo`s.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framenamechangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framenamechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameNameChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameNameChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNameChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framenavigationcompletedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framenavigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framenavigationstartingeventhandler.md
+++ b/1-0-2365-46/icorewebview2framenavigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framepermissionrequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framepermissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events for iframes.
 title: WebView2 Win32 C++ ICoreWebView2FramePermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FramePermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2framewebmessagereceivedeventhandler.md
+++ b/1-0-2365-46/icorewebview2framewebmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameWebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameWebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2getcookiescompletedhandler.md
+++ b/1-0-2365-46/icorewebview2getcookiescompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetCookies` method.
 title: WebView2 Win32 C++ ICoreWebView2GetCookiesCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetCookiesCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2getfaviconcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2getfaviconcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for the completion of the population of `imageStream`.
 title: WebView2 Win32 C++ ICoreWebView2GetFaviconCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetFaviconCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
+++ b/1-0-2365-46/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `GetNonDefaultPermissionSettings`.
 title: WebView2 Win32 C++ ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2getprocessextendedinfoscompletedhandler.md
+++ b/1-0-2365-46/icorewebview2getprocessextendedinfoscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetProcessExtendedInfos` method.
 title: WebView2 Win32 C++ ICoreWebView2GetProcessExtendedInfosCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetProcessExtendedInfosCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2historychangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2historychangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `HistoryChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2HistoryChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HistoryChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2httpheaderscollectioniterator.md
+++ b/1-0-2365-46/icorewebview2httpheaderscollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of HTTP headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpHeadersCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpHeadersCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2httprequestheaders.md
+++ b/1-0-2365-46/icorewebview2httprequestheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP request headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpRequestHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpRequestHeaders
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2httpresponseheaders.md
+++ b/1-0-2365-46/icorewebview2httpresponseheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP response headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpResponseHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpResponseHeaders
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDefaultDownloadDialogOpenChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2isdocumentplayingaudiochangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2isdocumentplayingaudiochangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDocumentPlayingAudioChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2ismutedchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2ismutedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsMutedChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsMutedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsMutedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2launchingexternalurischemeeventargs.md
+++ b/1-0-2365-46/icorewebview2launchingexternalurischemeeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2launchingexternalurischemeeventhandler.md
+++ b/1-0-2365-46/icorewebview2launchingexternalurischemeeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Event handler for the `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2movefocusrequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2movefocusrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `MoveFocusRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2movefocusrequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2movefocusrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `MoveFocusRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationcompletedeventargs.md
+++ b/1-0-2365-46/icorewebview2navigationcompletedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationCompleted` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationcompletedeventargs2.md
+++ b/1-0-2365-46/icorewebview2navigationcompletedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is an interface for the StatusCode property of ICoreWebView2NavigationCompletedEventArgs.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationcompletedeventhandler.md
+++ b/1-0-2365-46/icorewebview2navigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationstartingeventargs.md
+++ b/1-0-2365-46/icorewebview2navigationstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationstartingeventargs2.md
+++ b/1-0-2365-46/icorewebview2navigationstartingeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: The AdditionalAllowedFrameAncestors API that enable developers to provide additional allowed frame ancestors.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationstartingeventargs3.md
+++ b/1-0-2365-46/icorewebview2navigationstartingeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: The NavigationKind API that enables developers to get more information about navigation type.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2navigationstartingeventhandler.md
+++ b/1-0-2365-46/icorewebview2navigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2newbrowserversionavailableeventhandler.md
+++ b/1-0-2365-46/icorewebview2newbrowserversionavailableeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewBrowserVersionAvailable` events.
 title: WebView2 Win32 C++ ICoreWebView2NewBrowserVersionAvailableEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewBrowserVersionAvailableEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2newwindowrequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2newwindowrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NewWindowRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2newwindowrequestedeventargs2.md
+++ b/1-0-2365-46/icorewebview2newwindowrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2newwindowrequestedeventargs3.md
+++ b/1-0-2365-46/icorewebview2newwindowrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2newwindowrequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2newwindowrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewWindowRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2objectcollectionview.md
+++ b/1-0-2365-46/icorewebview2objectcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of generic objects.
 title: WebView2 Win32 C++ ICoreWebView2ObjectCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ObjectCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2permissionrequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2permissionrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `PermissionRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2permissionrequestedeventargs2.md
+++ b/1-0-2365-46/icorewebview2permissionrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2permissionrequestedeventargs3.md
+++ b/1-0-2365-46/icorewebview2permissionrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs2 interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2permissionrequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2permissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2permissionsetting.md
+++ b/1-0-2365-46/icorewebview2permissionsetting.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a permission setting.
 title: WebView2 Win32 C++ ICoreWebView2PermissionSetting
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSetting
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2permissionsettingcollectionview.md
+++ b/1-0-2365-46/icorewebview2permissionsettingcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of `PermissionSetting`s (origin, kind, and state).
 title: WebView2 Win32 C++ ICoreWebView2PermissionSettingCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSettingCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2pointerinfo.md
+++ b/1-0-2365-46/icorewebview2pointerinfo.md
@@ -1,7 +1,7 @@
 ---
 description: This mostly represents a combined win32 POINTER_INFO/POINTER_TOUCH_INFO/POINTER_PEN_INFO object.
 title: WebView2 Win32 C++ ICoreWebView2PointerInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PointerInfo
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2printcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2printcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2printsettings.md
+++ b/1-0-2365-46/icorewebview2printsettings.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2printsettings2.md
+++ b/1-0-2365-46/icorewebview2printsettings2.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2printtopdfcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2printtopdfcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2printtopdfstreamcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2printtopdfstreamcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdfStream` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfStreamCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfStreamCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processextendedinfo.md
+++ b/1-0-2365-46/icorewebview2processextendedinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides process with associated extended information in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfo
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processextendedinfocollection.md
+++ b/1-0-2365-46/icorewebview2processextendedinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing processInfo and associated extended information.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processfailedeventargs.md
+++ b/1-0-2365-46/icorewebview2processfailedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ProcessFailed` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processfailedeventargs2.md
+++ b/1-0-2365-46/icorewebview2processfailedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2ProcessFailedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processfailedeventhandler.md
+++ b/1-0-2365-46/icorewebview2processfailedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ProcessFailed` events.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processinfo.md
+++ b/1-0-2365-46/icorewebview2processinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a process in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfo
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processinfocollection.md
+++ b/1-0-2365-46/icorewebview2processinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing process id and corresponding process type.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2processinfoschangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2processinfoschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfosChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfosChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile.md
+++ b/1-0-2365-46/icorewebview2profile.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties to configure a Profile object.
 title: WebView2 Win32 C++ ICoreWebView2Profile
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile2.md
+++ b/1-0-2365-46/icorewebview2profile2.md
@@ -1,7 +1,7 @@
 ---
 description: Profile2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Profile2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile3.md
+++ b/1-0-2365-46/icorewebview2profile3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Profile interface to control levels of tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2Profile3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile4.md
+++ b/1-0-2365-46/icorewebview2profile4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for the permission management APIs.
 title: WebView2 Win32 C++ ICoreWebView2Profile4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile5.md
+++ b/1-0-2365-46/icorewebview2profile5.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for cookie manager.
 title: WebView2 Win32 C++ ICoreWebView2Profile5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile5
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile6.md
+++ b/1-0-2365-46/icorewebview2profile6.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing password-autosave and general-autofill.
 title: WebView2 Win32 C++ ICoreWebView2Profile6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile6
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile7.md
+++ b/1-0-2365-46/icorewebview2profile7.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2Profile7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile7
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profile8.md
+++ b/1-0-2365-46/icorewebview2profile8.md
@@ -1,7 +1,7 @@
 ---
 description: This is the profile interface that manages profile deletion.
 title: WebView2 Win32 C++ ICoreWebView2Profile8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile8
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profileaddbrowserextensioncompletedhandler.md
+++ b/1-0-2365-46/icorewebview2profileaddbrowserextensioncompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of loading an browser Extension.
 title: WebView2 Win32 C++ ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profiledeletedeventhandler.md
+++ b/1-0-2365-46/icorewebview2profiledeletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Profile.Deleted` event.
 title: WebView2 Win32 C++ ICoreWebView2ProfileDeletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileDeletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2profilegetbrowserextensionscompletedhandler.md
+++ b/1-0-2365-46/icorewebview2profilegetbrowserextensionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of getting the browser Extensions.
 title: WebView2 Win32 C++ ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2rasterizationscalechangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2rasterizationscalechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `RasterizationScaleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2RasterizationScaleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2RasterizationScaleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2scriptdialogopeningeventargs.md
+++ b/1-0-2365-46/icorewebview2scriptdialogopeningeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ScriptDialogOpening` event.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2scriptdialogopeningeventhandler.md
+++ b/1-0-2365-46/icorewebview2scriptdialogopeningeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ScriptDialogOpening` events.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2scriptexception.md
+++ b/1-0-2365-46/icorewebview2scriptexception.md
@@ -1,7 +1,7 @@
 ---
 description: This interface represents a JavaScript exception.
 title: WebView2 Win32 C++ ICoreWebView2ScriptException
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptException
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2servercertificateerrordetectedeventargs.md
+++ b/1-0-2365-46/icorewebview2servercertificateerrordetectedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2servercertificateerrordetectedeventhandler.md
+++ b/1-0-2365-46/icorewebview2servercertificateerrordetectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2setpermissionstatecompletedhandler.md
+++ b/1-0-2365-46/icorewebview2setpermissionstatecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `SetPermissionState`.
 title: WebView2 Win32 C++ ICoreWebView2SetPermissionStateCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SetPermissionStateCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings.md
+++ b/1-0-2365-46/icorewebview2settings.md
@@ -1,7 +1,7 @@
 ---
 description: Defines properties that enable, disable, or modify WebView features.
 title: WebView2 Win32 C++ ICoreWebView2Settings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings2.md
+++ b/1-0-2365-46/icorewebview2settings2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages the user agent.
 title: WebView2 Win32 C++ ICoreWebView2Settings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings3.md
+++ b/1-0-2365-46/icorewebview2settings3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages whether browser accelerator keys are enabled.
 title: WebView2 Win32 C++ ICoreWebView2Settings3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings3
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings4.md
+++ b/1-0-2365-46/icorewebview2settings4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage autofill.
 title: WebView2 Win32 C++ ICoreWebView2Settings4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings4
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings5.md
+++ b/1-0-2365-46/icorewebview2settings5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage pinch zoom.
 title: WebView2 Win32 C++ ICoreWebView2Settings5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings5
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings6.md
+++ b/1-0-2365-46/icorewebview2settings6.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage swipe navigation.
 title: WebView2 Win32 C++ ICoreWebView2Settings6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings6
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings7.md
+++ b/1-0-2365-46/icorewebview2settings7.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to hide Pdf toolbar items.
 title: WebView2 Win32 C++ ICoreWebView2Settings7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings7
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2settings8.md
+++ b/1-0-2365-46/icorewebview2settings8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage smartscreen.
 title: WebView2 Win32 C++ ICoreWebView2Settings8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings8
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2sharedbuffer.md
+++ b/1-0-2365-46/icorewebview2sharedbuffer.md
@@ -1,7 +1,7 @@
 ---
 description: The shared buffer object that is created by CreateSharedBuffer.
 title: WebView2 Win32 C++ ICoreWebView2SharedBuffer
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SharedBuffer
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2sourcechangedeventargs.md
+++ b/1-0-2365-46/icorewebview2sourcechangedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `SourceChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2sourcechangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2sourcechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `SourceChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2statechangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2statechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `StateChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2StateChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StateChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2statusbartextchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2statusbartextchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `StatusBarTextChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2StatusBarTextChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StatusBarTextChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2stringcollection.md
+++ b/1-0-2365-46/icorewebview2stringcollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of strings.
 title: WebView2 Win32 C++ ICoreWebView2StringCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StringCollection
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2trysuspendcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2trysuspendcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the TrySuspend result.
 title: WebView2 Win32 C++ ICoreWebView2TrySuspendCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2TrySuspendCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webmessagereceivedeventargs.md
+++ b/1-0-2365-46/icorewebview2webmessagereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebMessageReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webmessagereceivedeventargs2.md
+++ b/1-0-2365-46/icorewebview2webmessagereceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Extension of WebMessageReceivedEventArgs to provide access to additional WebMessage objects.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webmessagereceivedeventhandler.md
+++ b/1-0-2365-46/icorewebview2webmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourcerequest.md
+++ b/1-0-2365-46/icorewebview2webresourcerequest.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP request used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequest
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequest
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourcerequestedeventargs.md
+++ b/1-0-2365-46/icorewebview2webresourcerequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourcerequestedeventargs2.md
+++ b/1-0-2365-46/icorewebview2webresourcerequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourcerequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2webresourcerequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Runs when a URL request (through network, file, and so on) is made in the webview for a Web resource matching resource context filter and URL specified in `AddWebResourceRequestedFilter`.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourceresponse.md
+++ b/1-0-2365-46/icorewebview2webresourceresponse.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP response used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponse
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourceresponsereceivedeventargs.md
+++ b/1-0-2365-46/icorewebview2webresourceresponsereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the WebResourceResponseReceived event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourceresponsereceivedeventhandler.md
+++ b/1-0-2365-46/icorewebview2webresourceresponsereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebResourceResponseReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourceresponseview.md
+++ b/1-0-2365-46/icorewebview2webresourceresponseview.md
@@ -1,7 +1,7 @@
 ---
 description: View of the HTTP representation for a web resource response.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseView
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
+++ b/1-0-2365-46/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the ICoreWebView2WebResourceResponseView::GetContent method.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2windowcloserequestedeventhandler.md
+++ b/1-0-2365-46/icorewebview2windowcloserequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WindowCloseRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2WindowCloseRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowCloseRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2windowfeatures.md
+++ b/1-0-2365-46/icorewebview2windowfeatures.md
@@ -1,7 +1,7 @@
 ---
 description: The window features for a WebView popup window.
 title: WebView2 Win32 C++ ICoreWebView2WindowFeatures
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowFeatures
 topic_type: 
 - APIRef

--- a/1-0-2365-46/icorewebview2zoomfactorchangedeventhandler.md
+++ b/1-0-2365-46/icorewebview2zoomfactorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `ZoomFactorChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ZoomFactorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ZoomFactorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2365-46/index.md
+++ b/1-0-2365-46/index.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 C++ Reference
 title: WebView2 Win32 C++ Reference
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 ---
 

--- a/1-0-2365-46/webview2-idl.md
+++ b/1-0-2365-46/webview2-idl.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 Globals
 title: Globals
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2.md
+++ b/1-0-2415-prerelease/icorewebview2.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 enables you to host web content using the latest Microsoft Edge browser and web technology.
 title: WebView2 Win32 C++ ICoreWebView2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_10.md
+++ b/1-0-2415-prerelease/icorewebview2_10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_9 that supports BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_10
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_11.md
+++ b/1-0-2415-prerelease/icorewebview2_11.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_10 that supports sessionId for CDP method calls and ContextMenuRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_11
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_12.md
+++ b/1-0-2415-prerelease/icorewebview2_12.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_11 that supports StatusBarTextChanged event.
 title: WebView2 Win32 C++ ICoreWebView2_12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_12
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_13.md
+++ b/1-0-2415-prerelease/icorewebview2_13.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_12 that supports Profile API.
 title: WebView2 Win32 C++ ICoreWebView2_13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_13
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_14.md
+++ b/1-0-2415-prerelease/icorewebview2_14.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_13 that adds ServerCertificate support.
 title: WebView2 Win32 C++ ICoreWebView2_14
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_14
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_15.md
+++ b/1-0-2415-prerelease/icorewebview2_15.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_14 that supports status Favicons.
 title: WebView2 Win32 C++ ICoreWebView2_15
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_15
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_16.md
+++ b/1-0-2415-prerelease/icorewebview2_16.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface to support printing.
 title: WebView2 Win32 C++ ICoreWebView2_16
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_16
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_17.md
+++ b/1-0-2415-prerelease/icorewebview2_17.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_16 that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2_17
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_17
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_18.md
+++ b/1-0-2415-prerelease/icorewebview2_18.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_17 that manages navigation requests to URI schemes registered with the OS.
 title: WebView2 Win32 C++ ICoreWebView2_18
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_18
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_19.md
+++ b/1-0-2415-prerelease/icorewebview2_19.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_18 that manages memory usage target level.
 title: WebView2 Win32 C++ ICoreWebView2_19
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_19
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_2.md
+++ b/1-0-2415-prerelease/icorewebview2_2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_20.md
+++ b/1-0-2415-prerelease/icorewebview2_20.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_19 that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2_20
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_20
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_21.md
+++ b/1-0-2415-prerelease/icorewebview2_21.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface for getting string and exception with ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2_21
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_21
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_22.md
+++ b/1-0-2415-prerelease/icorewebview2_22.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2 that allows to set filters in order to receive WebResourceRequested events for service workers, shared workers and different origin iframes.
 title: WebView2 Win32 C++ ICoreWebView2_22
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_22
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_3.md
+++ b/1-0-2415-prerelease/icorewebview2_3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_2 interface.
 title: WebView2 Win32 C++ ICoreWebView2_3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_4.md
+++ b/1-0-2415-prerelease/icorewebview2_4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_3 interface to support FrameCreated and DownloadStarting events.
 title: WebView2 Win32 C++ ICoreWebView2_4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_5.md
+++ b/1-0-2415-prerelease/icorewebview2_5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2_4 interface to support ClientCertificateRequested event.
 title: WebView2 Win32 C++ ICoreWebView2_5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_5
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_6.md
+++ b/1-0-2415-prerelease/icorewebview2_6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_5 that manages opening the browser task manager window.
 title: WebView2 Win32 C++ ICoreWebView2_6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_6
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_7.md
+++ b/1-0-2415-prerelease/icorewebview2_7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_6 that supports printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2_7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_7
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_8.md
+++ b/1-0-2415-prerelease/icorewebview2_8.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_7 that supports media features.
 title: WebView2 Win32 C++ ICoreWebView2_8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_8
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2_9.md
+++ b/1-0-2415-prerelease/icorewebview2_9.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of ICoreWebView2_8 that default download dialog positioning and anchoring.
 title: WebView2 Win32 C++ ICoreWebView2_9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2_9
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2acceleratorkeypressedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2acceleratorkeypressedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `AcceleratorKeyPressed` event.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2acceleratorkeypressedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2acceleratorkeypressedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is This is a continuation of the ICoreWebView2AcceleratorKeyPressedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2acceleratorkeypressedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2acceleratorkeypressedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `AcceleratorKeyPressed` events.
 title: WebView2 Win32 C++ ICoreWebView2AcceleratorKeyPressedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AcceleratorKeyPressedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2addscripttoexecuteondocumentcreatedcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `AddScriptToExecuteOnDocumentCreated` method.
 title: WebView2 Win32 C++ ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2basicauthenticationrequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2basicauthenticationrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2basicauthenticationrequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2basicauthenticationrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the BasicAuthenticationRequested event.
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2basicauthenticationresponse.md
+++ b/1-0-2415-prerelease/icorewebview2basicauthenticationresponse.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a Basic HTTP authentication response that contains a user name and a password as according to RFC7617 (https://tools.ietf.org/html/rfc7617)
 title: WebView2 Win32 C++ ICoreWebView2BasicAuthenticationResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BasicAuthenticationResponse
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2browserextension.md
+++ b/1-0-2415-prerelease/icorewebview2browserextension.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing an Extension, which includes an ID, name, and whether it is enabled or not, and the ability to Remove the Extension, and enable or disable it.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtension
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtension
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2browserextensionenablecompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2browserextensionenablecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of setting the browser Extension as enabled or disabled.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionEnableCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionEnableCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2browserextensionlist.md
+++ b/1-0-2415-prerelease/icorewebview2browserextensionlist.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for managing browser Extension Lists from user profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionList
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2browserextensionremovecompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2browserextensionremovecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of removing the browser Extension from the Profile.
 title: WebView2 Win32 C++ ICoreWebView2BrowserExtensionRemoveCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserExtensionRemoveCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2browserprocessexitedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2browserprocessexitedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2browserprocessexitedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2browserprocessexitedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `BrowserProcessExited` events.
 title: WebView2 Win32 C++ ICoreWebView2BrowserProcessExitedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BrowserProcessExitedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2bytesreceivedchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2bytesreceivedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `BytesReceivedChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2BytesReceivedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2BytesReceivedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2calldevtoolsprotocolmethodcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `CallDevToolsProtocolMethod` completion results.
 title: WebView2 Win32 C++ ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2capturepreviewcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2capturepreviewcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `CapturePreview` method.
 title: WebView2 Win32 C++ ICoreWebView2CapturePreviewCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CapturePreviewCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2certificate.md
+++ b/1-0-2415-prerelease/icorewebview2certificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2Certificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Certificate
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2clearbrowsingdatacompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2clearbrowsingdatacompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the ClearBrowsingData result.
 title: WebView2 Win32 C++ ICoreWebView2ClearBrowsingDataCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearBrowsingDataCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2clearservercertificateerroractionscompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2clearservercertificateerroractionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ClearServerCertificateErrorActions` method.
 title: WebView2 Win32 C++ ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClearServerCertificateErrorActionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2clientcertificate.md
+++ b/1-0-2415-prerelease/icorewebview2clientcertificate.md
@@ -1,7 +1,7 @@
 ---
 description: Provides access to the client certificate metadata.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificate
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificate
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2clientcertificatecollection.md
+++ b/1-0-2415-prerelease/icorewebview2clientcertificatecollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of client certificate object.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateCollection
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2clientcertificaterequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2clientcertificaterequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2clientcertificaterequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2clientcertificaterequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ClientCertificateRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ClientCertificateRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ClientCertificateRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2compositioncontroller.md
+++ b/1-0-2415-prerelease/icorewebview2compositioncontroller.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Controller interface to support visual hosting.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2compositioncontroller2.md
+++ b/1-0-2415-prerelease/icorewebview2compositioncontroller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2CompositionController interface.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2compositioncontroller3.md
+++ b/1-0-2415-prerelease/icorewebview2compositioncontroller3.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is the continuation of the ICoreWebView2CompositionController2 interface to manage drag and drop.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2compositioncontroller4.md
+++ b/1-0-2415-prerelease/icorewebview2compositioncontroller4.md
@@ -1,7 +1,7 @@
 ---
 description: This Interface includes an API which enables non-client hit-testing support for WebView2.
 title: WebView2 Win32 C++ ICoreWebView2CompositionController4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CompositionController4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2containsfullscreenelementchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2containsfullscreenelementchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContainsFullScreenElementChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ContainsFullScreenElementChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContainsFullScreenElementChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contentloadingeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2contentloadingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContentLoading` event.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contentloadingeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2contentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events.
 title: WebView2 Win32 C++ ICoreWebView2ContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contextmenuitem.md
+++ b/1-0-2415-prerelease/icorewebview2contextmenuitem.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a context menu item of a context menu displayed by WebView.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItem
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItem
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contextmenuitemcollection.md
+++ b/1-0-2415-prerelease/icorewebview2contextmenuitemcollection.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a collection of `ContextMenuItem` objects.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuItemCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuItemCollection
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contextmenurequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2contextmenurequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ContextMenuRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contextmenurequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2contextmenurequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContextMenuRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2contextmenutarget.md
+++ b/1-0-2415-prerelease/icorewebview2contextmenutarget.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the information regarding the context menu target.
 title: WebView2 Win32 C++ ICoreWebView2ContextMenuTarget
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ContextMenuTarget
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2controller.md
+++ b/1-0-2415-prerelease/icorewebview2controller.md
@@ -1,7 +1,7 @@
 ---
 description: The owner of the `CoreWebView2` object that provides support for resizing, showing and hiding, focusing, and other functionality related to windowing and composition.
 title: WebView2 Win32 C++ ICoreWebView2Controller
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2controller2.md
+++ b/1-0-2415-prerelease/icorewebview2controller2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2controller3.md
+++ b/1-0-2415-prerelease/icorewebview2controller3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Controller2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2controller4.md
+++ b/1-0-2415-prerelease/icorewebview2controller4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Controller4 interface.
 title: WebView2 Win32 C++ ICoreWebView2Controller4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Controller4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2controlleroptions.md
+++ b/1-0-2415-prerelease/icorewebview2controlleroptions.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to manage profile options that created by 'CreateCoreWebView2ControllerOptions'.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2controlleroptions2.md
+++ b/1-0-2415-prerelease/icorewebview2controlleroptions2.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface in ControllerOptions for ScriptLocale.
 title: WebView2 Win32 C++ ICoreWebView2ControllerOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ControllerOptions2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2cookie.md
+++ b/1-0-2415-prerelease/icorewebview2cookie.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties that are used to manage an ICoreWebView2Cookie.
 title: WebView2 Win32 C++ ICoreWebView2Cookie
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Cookie
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2cookielist.md
+++ b/1-0-2415-prerelease/icorewebview2cookielist.md
@@ -1,7 +1,7 @@
 ---
 description: A list of cookie objects.
 title: WebView2 Win32 C++ ICoreWebView2CookieList
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieList
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2cookiemanager.md
+++ b/1-0-2415-prerelease/icorewebview2cookiemanager.md
@@ -1,7 +1,7 @@
 ---
 description: Creates, adds or updates, gets, or or view the cookies.
 title: WebView2 Win32 C++ ICoreWebView2CookieManager
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CookieManager
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2createcorewebview2compositioncontrollercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the CoreWebView2Controller created via CreateCoreWebView2CompositionController.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2createcorewebview2controllercompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2createcorewebview2controllercompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Controller` created using `CreateCoreWebView2Controller`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2ControllerCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2createcorewebview2environmentcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2createcorewebview2environmentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `WebView2Environment` created using `CreateCoreWebView2Environment`.
 title: WebView2 Win32 C++ ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2cursorchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2cursorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive CursorChanged events.
 title: WebView2 Win32 C++ ICoreWebView2CursorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CursorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2customitemselectedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2customitemselectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Raised to notify the host that the end user selected a custom `ContextMenuItem`.
 title: WebView2 Win32 C++ ICoreWebView2CustomItemSelectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomItemSelectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2customschemeregistration.md
+++ b/1-0-2415-prerelease/icorewebview2customschemeregistration.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the registration of a custom scheme with the CoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2CustomSchemeRegistration
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2CustomSchemeRegistration
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2deferral.md
+++ b/1-0-2415-prerelease/icorewebview2deferral.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to complete deferrals on event args that support getting deferrals using the `GetDeferral` method.
 title: WebView2 Win32 C++ ICoreWebView2Deferral
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Deferral
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DevToolsProtocolEventReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2DevToolsProtocolEventReceivedEventArgs interface that provides the session ID of the target where the event originates from.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DevToolsProtocolEventReceived` events from the WebView.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceiver.md
+++ b/1-0-2415-prerelease/icorewebview2devtoolsprotocoleventreceiver.md
@@ -1,7 +1,7 @@
 ---
 description: A Receiver is created for a particular DevTools Protocol event and allows you to subscribe and unsubscribe from that event.
 title: WebView2 Win32 C++ ICoreWebView2DevToolsProtocolEventReceiver
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DevToolsProtocolEventReceiver
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2documenttitlechangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2documenttitlechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DocumentTitleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2DocumentTitleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DocumentTitleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2domcontentloadedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2domcontentloadedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the DOMContentLoaded event.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2domcontentloadedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2domcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events.
 title: WebView2 Win32 C++ ICoreWebView2DOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2downloadoperation.md
+++ b/1-0-2415-prerelease/icorewebview2downloadoperation.md
@@ -1,7 +1,7 @@
 ---
 description: Represents a download operation.
 title: WebView2 Win32 C++ ICoreWebView2DownloadOperation
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadOperation
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2downloadstartingeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2downloadstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2downloadstartingeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2downloadstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Add an event handler for the `DownloadStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2DownloadStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2DownloadStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment.md
+++ b/1-0-2415-prerelease/icorewebview2environment.md
@@ -1,7 +1,7 @@
 ---
 description: Represents the WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment10.md
+++ b/1-0-2415-prerelease/icorewebview2environment10.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is used to create ICoreWebView2ControllerOptions object, which can be passed as a parameter in `CreateCoreWebView2ControllerWithOptions` and `CreateCoreWebView2CompositionControllerWithOptions` function for multiple profiles support.
 title: WebView2 Win32 C++ ICoreWebView2Environment10
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment10
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment11.md
+++ b/1-0-2415-prerelease/icorewebview2environment11.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting the crash dump folder path.
 title: WebView2 Win32 C++ ICoreWebView2Environment11
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment11
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment12.md
+++ b/1-0-2415-prerelease/icorewebview2environment12.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating shared buffer object.
 title: WebView2 Win32 C++ ICoreWebView2Environment12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment12
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment13.md
+++ b/1-0-2415-prerelease/icorewebview2environment13.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for getting process with associated information.
 title: WebView2 Win32 C++ ICoreWebView2Environment13
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment13
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment2.md
+++ b/1-0-2415-prerelease/icorewebview2environment2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment3.md
+++ b/1-0-2415-prerelease/icorewebview2environment3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment4.md
+++ b/1-0-2415-prerelease/icorewebview2environment4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment3 interface.
 title: WebView2 Win32 C++ ICoreWebView2Environment4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment5.md
+++ b/1-0-2415-prerelease/icorewebview2environment5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment4 interface that supports the `BrowserProcessExited` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment5
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment6.md
+++ b/1-0-2415-prerelease/icorewebview2environment6.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment that supports creating print settings for printing to PDF.
 title: WebView2 Win32 C++ ICoreWebView2Environment6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment6
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment7.md
+++ b/1-0-2415-prerelease/icorewebview2environment7.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2Environment7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment7
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment8.md
+++ b/1-0-2415-prerelease/icorewebview2environment8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment7 interface that supports the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2Environment8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment8
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environment9.md
+++ b/1-0-2415-prerelease/icorewebview2environment9.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Environment interface for creating CoreWebView2 ContextMenuItem objects.
 title: WebView2 Win32 C++ ICoreWebView2Environment9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Environment9
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environmentoptions.md
+++ b/1-0-2415-prerelease/icorewebview2environmentoptions.md
@@ -1,7 +1,7 @@
 ---
 description: Options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environmentoptions2.md
+++ b/1-0-2415-prerelease/icorewebview2environmentoptions2.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environmentoptions3.md
+++ b/1-0-2415-prerelease/icorewebview2environmentoptions3.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage crash reporting.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environmentoptions4.md
+++ b/1-0-2415-prerelease/icorewebview2environmentoptions4.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment that manages custom scheme registration.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environmentoptions5.md
+++ b/1-0-2415-prerelease/icorewebview2environmentoptions5.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions5
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2environmentoptions6.md
+++ b/1-0-2415-prerelease/icorewebview2environmentoptions6.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create WebView2 Environment to manage browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2EnvironmentOptions6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EnvironmentOptions6
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2estimatedendtimechangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2estimatedendtimechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `EstimatedEndTimeChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2EstimatedEndTimeChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2EstimatedEndTimeChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2executescriptcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2executescriptcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `ExecuteScript` method.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2executescriptresult.md
+++ b/1-0-2415-prerelease/icorewebview2executescriptresult.md
@@ -1,7 +1,7 @@
 ---
 description: This is the result for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptResult
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptResult
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2executescriptwithresultcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2executescriptwithresultcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for ExecuteScriptWithResult.
 title: WebView2 Win32 C++ ICoreWebView2ExecuteScriptWithResultCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExecuteScriptWithResultCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimental20.md
+++ b/1-0-2415-prerelease/icorewebview2experimental20.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2 experimental interface for custom data partition.
 title: WebView2 Win32 C++ ICoreWebView2Experimental20
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Experimental20
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimental22.md
+++ b/1-0-2415-prerelease/icorewebview2experimental22.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Experimental22 interface that manages WebView2 Web Notification functionality.
 title: WebView2 Win32 C++ ICoreWebView2Experimental22
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Experimental22
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalclearcustomdatapartitioncompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalclearcustomdatapartitioncompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the ClearCustomDataPartition result.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalClearCustomDataPartitionCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalClearCustomDataPartitionCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalcompositioncontroller4.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalcompositioncontroller4.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2CompositionController.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalCompositionController4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalCompositionController4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalcontrolleroptions2.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalcontrolleroptions2.md
@@ -1,7 +1,7 @@
 ---
 description: Controller option used to allow user input pass through the browser and make them received in the host app process.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalControllerOptions2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalControllerOptions2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalenvironment12.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalenvironment12.md
@@ -1,7 +1,7 @@
 ---
 description: This is ICoreWebView2ExperimentalEnvironment12 that returns the texture stream interface.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalEnvironment12
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalEnvironment12
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalenvironment3.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalenvironment3.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is an extension of the ICoreWebView2Environment that manages updating Edge WebView2 Runtime.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalEnvironment3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalEnvironment3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalenvironmentoptions.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalenvironmentoptions.md
@@ -1,7 +1,7 @@
 ---
 description: Additional options used to create the WebView2 Environment that support specifying the `ReleaseChannels` and `ChannelSearchKind`.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalEnvironmentOptions
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalEnvironmentOptions
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalnotification.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalnotification.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2ExperimentalNotification that represents a HTML Notification object.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotification
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotification
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalnotificationcloserequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalnotificationcloserequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `CloseRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotificationCloseRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotificationCloseRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalnotificationreceivedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalnotificationreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NotificationReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotificationReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotificationReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalnotificationreceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalnotificationreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `NotificationReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalNotificationReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalNotificationReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalprocessfailedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalprocessfailedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2ProcessFailedEventArgs2 interface fot getting blocked file for code integrity process failures.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalProcessFailedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalProcessFailedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalprofile7.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalprofile7.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2 experimental profile interface.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalProfile7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalProfile7
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalrenderadapterluidchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalrenderadapterluidchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for the browser process's display LUID change.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalRenderAdapterLUIDChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalRenderAdapterLUIDChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexture.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexture.md
@@ -1,7 +1,7 @@
 ---
 description: texture that the host writes to so that the Renderer will render on it.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTexture
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTexture
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestream.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestream.md
@@ -1,7 +1,7 @@
 ---
 description: This is the interface that handles texture streaming.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStream
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStream
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: The event args for the `ICoreWebViewTextureStream ErrorReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamErrorReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamErrorReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamerrorreceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for texture stream rendering error.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamErrorReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamErrorReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamstartrequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamstartrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for new texture stream request.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamStartRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamStartRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamstoppedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamstoppedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for stop request of texture stream.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamStoppedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamStoppedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: The event args for the `ICoreWebView2TextureStream WebTextureReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamwebtexturereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for web texture.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamWebTextureReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentaltexturestreamwebtexturestreamstoppedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentaltexturestreamwebtexturestreamstoppedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the callback for web texture stop.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalTextureStreamWebTextureStreamStoppedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalTextureStreamWebTextureStreamStoppedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalupdateruntimecompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalupdateruntimecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the UpdateRuntime result.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalUpdateRuntimeCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalUpdateRuntimeCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalupdateruntimeresult.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalupdateruntimeresult.md
@@ -1,7 +1,7 @@
 ---
 description: The UpdateRuntime operation result.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalUpdateRuntimeResult
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalUpdateRuntimeResult
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2experimentalwebtexture.md
+++ b/1-0-2415-prerelease/icorewebview2experimentalwebtexture.md
@@ -1,7 +1,7 @@
 ---
 description: Received texture that the renderer writes to so that the host will read on it.
 title: WebView2 Win32 C++ ICoreWebView2ExperimentalWebTexture
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ExperimentalWebTexture
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2faviconchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2faviconchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for when the `Favicon` is changed.
 title: WebView2 Win32 C++ ICoreWebView2FaviconChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FaviconChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2file.md
+++ b/1-0-2415-prerelease/icorewebview2file.md
@@ -1,7 +1,7 @@
 ---
 description: Representation of a DOM File object passed via WebMessage.
 title: WebView2 Win32 C++ ICoreWebView2File
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2File
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2focuschangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2focuschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `GotFocus` and `LostFocus` events.
 title: WebView2 Win32 C++ ICoreWebView2FocusChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FocusChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frame.md
+++ b/1-0-2415-prerelease/icorewebview2frame.md
@@ -1,7 +1,7 @@
 ---
 description: ICoreWebView2Frame provides direct access to the iframes information.
 title: WebView2 Win32 C++ ICoreWebView2Frame
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frame2.md
+++ b/1-0-2415-prerelease/icorewebview2frame2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Frame interface with navigation events, executing script and posting web messages.
 title: WebView2 Win32 C++ ICoreWebView2Frame2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frame3.md
+++ b/1-0-2415-prerelease/icorewebview2frame3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports PermissionRequested.
 title: WebView2 Win32 C++ ICoreWebView2Frame3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frame4.md
+++ b/1-0-2415-prerelease/icorewebview2frame4.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that supports shared buffer based on file mapping.
 title: WebView2 Win32 C++ ICoreWebView2Frame4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frame5.md
+++ b/1-0-2415-prerelease/icorewebview2frame5.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Frame interface that provides the `FrameId` property.
 title: WebView2 Win32 C++ ICoreWebView2Frame5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Frame5
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framecontentloadingeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framecontentloadingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ContentLoading` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameContentLoadingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameContentLoadingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framecreatedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2framecreatedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `FrameCreated` events.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framecreatedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framecreatedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameCreated` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameCreatedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameCreatedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framedestroyedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framedestroyedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameDestroyed` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameDestroyedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDestroyedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framedomcontentloadedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framedomcontentloadedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `DOMContentLoaded` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameDOMContentLoadedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameDOMContentLoadedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frameinfo.md
+++ b/1-0-2415-prerelease/icorewebview2frameinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a frame in the ICoreWebView2.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frameinfo2.md
+++ b/1-0-2415-prerelease/icorewebview2frameinfo2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2FrameInfo interface that provides `ParentFrameInfo`, `FrameId` and `FrameKind` properties.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfo2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfo2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frameinfocollection.md
+++ b/1-0-2415-prerelease/icorewebview2frameinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: Collection of `FrameInfo`s (name and source).
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2frameinfocollectioniterator.md
+++ b/1-0-2415-prerelease/icorewebview2frameinfocollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of `FrameInfo`s.
 title: WebView2 Win32 C++ ICoreWebView2FrameInfoCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameInfoCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framenamechangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framenamechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `FrameNameChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2FrameNameChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNameChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framenavigationcompletedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framenavigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framenavigationstartingeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framenavigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameNavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameNavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framepermissionrequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framepermissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events for iframes.
 title: WebView2 Win32 C++ ICoreWebView2FramePermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FramePermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2framewebmessagereceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2framewebmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events for iframe.
 title: WebView2 Win32 C++ ICoreWebView2FrameWebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2FrameWebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2getcookiescompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2getcookiescompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetCookies` method.
 title: WebView2 Win32 C++ ICoreWebView2GetCookiesCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetCookiesCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2getfaviconcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2getfaviconcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This interface is a handler for the completion of the population of `imageStream`.
 title: WebView2 Win32 C++ ICoreWebView2GetFaviconCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetFaviconCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2getnondefaultpermissionsettingscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `GetNonDefaultPermissionSettings`.
 title: WebView2 Win32 C++ ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2getprocessextendedinfoscompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2getprocessextendedinfoscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `GetProcessExtendedInfos` method.
 title: WebView2 Win32 C++ ICoreWebView2GetProcessExtendedInfosCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2GetProcessExtendedInfosCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2historychangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2historychangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `HistoryChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2HistoryChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HistoryChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2httpheaderscollectioniterator.md
+++ b/1-0-2415-prerelease/icorewebview2httpheaderscollectioniterator.md
@@ -1,7 +1,7 @@
 ---
 description: Iterator for a collection of HTTP headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpHeadersCollectionIterator
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpHeadersCollectionIterator
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2httprequestheaders.md
+++ b/1-0-2415-prerelease/icorewebview2httprequestheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP request headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpRequestHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpRequestHeaders
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2httpresponseheaders.md
+++ b/1-0-2415-prerelease/icorewebview2httpresponseheaders.md
@@ -1,7 +1,7 @@
 ---
 description: HTTP response headers.
 title: WebView2 Win32 C++ ICoreWebView2HttpResponseHeaders
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2HttpResponseHeaders
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2isdefaultdownloaddialogopenchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDefaultDownloadDialogOpenChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDefaultDownloadDialogOpenChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2isdocumentplayingaudiochangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2isdocumentplayingaudiochangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsDocumentPlayingAudioChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsDocumentPlayingAudioChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2ismutedchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2ismutedchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `IsMutedChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2IsMutedChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2IsMutedChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2launchingexternalurischemeeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2launchingexternalurischemeeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventArgs
 topic_type: 
 - APIRef
@@ -62,7 +62,7 @@ The origin initiating the external URI scheme launch.
 
 > public HRESULT [get_InitiatingOrigin](#get_initiatingorigin)(LPWSTR * value)
 
-The origin will be an empty string if the request is initiated by calling `CoreWebView2.Navigate` on the external URI scheme. If a script initiates the navigation, the `InitiatingOrigin` will be the top-level document's `Source`, for example, if `window.location` is set to `"calculator://", the `InitiatingOrigin`will be set to`calculator://`. If the request is initiated from a child frame, the`InitiatingOrigin` will be the source of that child frame.
+The origin will be an empty string if the request is initiated by calling `CoreWebView2.Navigate` on the external URI scheme. If a script initiates the navigation, the `InitiatingOrigin` will be the top-level document's `Source`, for example, if `window.location` is set to `"calculator://"`, the `InitiatingOrigin` will be set to`calculator://`. If the request is initiated from a child frame, the `InitiatingOrigin` will be the source of that child frame. If the `InitiatingOrigin` is [opaque](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque), the `InitiatingOrigin` reported in the event args will be its precursor origin. The precursor origin is the origin that created the opaque origin. For example, if a frame on example.com opens a subframe with a different opaque origin, the subframe's precursor origin is example.com.
 
 #### get_IsUserInitiated
 

--- a/1-0-2415-prerelease/icorewebview2launchingexternalurischemeeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2launchingexternalurischemeeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Event handler for the `LaunchingExternalUriScheme` event.
 title: WebView2 Win32 C++ ICoreWebView2LaunchingExternalUriSchemeEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2LaunchingExternalUriSchemeEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2movefocusrequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2movefocusrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `MoveFocusRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2movefocusrequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2movefocusrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `MoveFocusRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2MoveFocusRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2MoveFocusRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationcompletedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2navigationcompletedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationCompleted` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationcompletedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2navigationcompletedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is an interface for the StatusCode property of ICoreWebView2NavigationCompletedEventArgs.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationcompletedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2navigationcompletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationCompleted` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationCompletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationCompletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationstartingeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2navigationstartingeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NavigationStarting` event.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationstartingeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2navigationstartingeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: The AdditionalAllowedFrameAncestors API that enable developers to provide additional allowed frame ancestors.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationstartingeventargs3.md
+++ b/1-0-2415-prerelease/icorewebview2navigationstartingeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: The NavigationKind API that enables developers to get more information about navigation type.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2navigationstartingeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2navigationstartingeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NavigationStarting` events.
 title: WebView2 Win32 C++ ICoreWebView2NavigationStartingEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NavigationStartingEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2newbrowserversionavailableeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2newbrowserversionavailableeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewBrowserVersionAvailable` events.
 title: WebView2 Win32 C++ ICoreWebView2NewBrowserVersionAvailableEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewBrowserVersionAvailableEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2newwindowrequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2newwindowrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `NewWindowRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2newwindowrequestedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2newwindowrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2newwindowrequestedeventargs3.md
+++ b/1-0-2415-prerelease/icorewebview2newwindowrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2NewWindowRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2newwindowrequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2newwindowrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `NewWindowRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2NewWindowRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NewWindowRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2nonclientregionchangedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2nonclientregionchangedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: This is the Interface for non-client region change event args.
 title: WebView2 Win32 C++ ICoreWebView2NonClientRegionChangedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NonClientRegionChangedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2nonclientregionchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2nonclientregionchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: This is the Interface of the event handler for the non-client region changed event.
 title: WebView2 Win32 C++ ICoreWebView2NonClientRegionChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2NonClientRegionChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2objectcollectionview.md
+++ b/1-0-2415-prerelease/icorewebview2objectcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of generic objects.
 title: WebView2 Win32 C++ ICoreWebView2ObjectCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ObjectCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2permissionrequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2permissionrequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `PermissionRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2permissionrequestedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2permissionrequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2permissionrequestedeventargs3.md
+++ b/1-0-2415-prerelease/icorewebview2permissionrequestedeventargs3.md
@@ -1,7 +1,7 @@
 ---
 description: This is a continuation of the ICoreWebView2PermissionRequestedEventArgs2 interface.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventArgs3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventArgs3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2permissionrequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2permissionrequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `PermissionRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2PermissionRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2permissionsetting.md
+++ b/1-0-2415-prerelease/icorewebview2permissionsetting.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a permission setting.
 title: WebView2 Win32 C++ ICoreWebView2PermissionSetting
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSetting
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2permissionsettingcollectionview.md
+++ b/1-0-2415-prerelease/icorewebview2permissionsettingcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only collection of `PermissionSetting`s (origin, kind, and state).
 title: WebView2 Win32 C++ ICoreWebView2PermissionSettingCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PermissionSettingCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2pointerinfo.md
+++ b/1-0-2415-prerelease/icorewebview2pointerinfo.md
@@ -1,7 +1,7 @@
 ---
 description: This mostly represents a combined win32 POINTER_INFO/POINTER_TOUCH_INFO/POINTER_PEN_INFO object.
 title: WebView2 Win32 C++ ICoreWebView2PointerInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PointerInfo
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2printcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2printcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2printsettings.md
+++ b/1-0-2415-prerelease/icorewebview2printsettings.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2printsettings2.md
+++ b/1-0-2415-prerelease/icorewebview2printsettings2.md
@@ -1,7 +1,7 @@
 ---
 description: Settings used by the `Print` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintSettings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintSettings2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2printtopdfcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2printtopdfcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdf` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2printtopdfstreamcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2printtopdfstreamcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the `PrintToPdfStream` method.
 title: WebView2 Win32 C++ ICoreWebView2PrintToPdfStreamCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2PrintToPdfStreamCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processextendedinfo.md
+++ b/1-0-2415-prerelease/icorewebview2processextendedinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides process with associated extended information in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfo
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processextendedinfocollection.md
+++ b/1-0-2415-prerelease/icorewebview2processextendedinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing processInfo and associated extended information.
 title: WebView2 Win32 C++ ICoreWebView2ProcessExtendedInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessExtendedInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processfailedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2processfailedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ProcessFailed` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processfailedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2processfailedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2ProcessFailedEventArgs interface.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processfailedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2processfailedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ProcessFailed` events.
 title: WebView2 Win32 C++ ICoreWebView2ProcessFailedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessFailedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processinfo.md
+++ b/1-0-2415-prerelease/icorewebview2processinfo.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties for a process in the ICoreWebView2Environment.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfo
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfo
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processinfocollection.md
+++ b/1-0-2415-prerelease/icorewebview2processinfocollection.md
@@ -1,7 +1,7 @@
 ---
 description: A list containing process id and corresponding process type.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfoCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfoCollection
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2processinfoschangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2processinfoschangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ProcessInfosChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2ProcessInfosChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProcessInfosChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile.md
+++ b/1-0-2415-prerelease/icorewebview2profile.md
@@ -1,7 +1,7 @@
 ---
 description: Provides a set of properties to configure a Profile object.
 title: WebView2 Win32 C++ ICoreWebView2Profile
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile2.md
+++ b/1-0-2415-prerelease/icorewebview2profile2.md
@@ -1,7 +1,7 @@
 ---
 description: Profile2 interface.
 title: WebView2 Win32 C++ ICoreWebView2Profile2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile3.md
+++ b/1-0-2415-prerelease/icorewebview2profile3.md
@@ -1,7 +1,7 @@
 ---
 description: This is an extension of the ICoreWebView2Profile interface to control levels of tracking prevention.
 title: WebView2 Win32 C++ ICoreWebView2Profile3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile4.md
+++ b/1-0-2415-prerelease/icorewebview2profile4.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for the permission management APIs.
 title: WebView2 Win32 C++ ICoreWebView2Profile4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile5.md
+++ b/1-0-2415-prerelease/icorewebview2profile5.md
@@ -1,7 +1,7 @@
 ---
 description: This is the ICoreWebView2Profile interface for cookie manager.
 title: WebView2 Win32 C++ ICoreWebView2Profile5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile5
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile6.md
+++ b/1-0-2415-prerelease/icorewebview2profile6.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing password-autosave and general-autofill.
 title: WebView2 Win32 C++ ICoreWebView2Profile6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile6
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile7.md
+++ b/1-0-2415-prerelease/icorewebview2profile7.md
@@ -1,7 +1,7 @@
 ---
 description: Interfaces in profile for managing browser extensions.
 title: WebView2 Win32 C++ ICoreWebView2Profile7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile7
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profile8.md
+++ b/1-0-2415-prerelease/icorewebview2profile8.md
@@ -1,7 +1,7 @@
 ---
 description: This is the profile interface that manages profile deletion.
 title: WebView2 Win32 C++ ICoreWebView2Profile8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Profile8
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profileaddbrowserextensioncompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2profileaddbrowserextensioncompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of loading an browser Extension.
 title: WebView2 Win32 C++ ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileAddBrowserExtensionCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profiledeletedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2profiledeletedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the `CoreWebView2Profile.Deleted` event.
 title: WebView2 Win32 C++ ICoreWebView2ProfileDeletedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileDeletedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2profilegetbrowserextensionscompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2profilegetbrowserextensionscompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the result of getting the browser Extensions.
 title: WebView2 Win32 C++ ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ProfileGetBrowserExtensionsCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2rasterizationscalechangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2rasterizationscalechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `RasterizationScaleChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2RasterizationScaleChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2RasterizationScaleChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2regionrectcollectionview.md
+++ b/1-0-2415-prerelease/icorewebview2regionrectcollectionview.md
@@ -1,7 +1,7 @@
 ---
 description: This Interface Represents a Collection of Region Rects.
 title: WebView2 Win32 C++ ICoreWebView2RegionRectCollectionView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2RegionRectCollectionView
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2scriptdialogopeningeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2scriptdialogopeningeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ScriptDialogOpening` event.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2scriptdialogopeningeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2scriptdialogopeningeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `ScriptDialogOpening` events.
 title: WebView2 Win32 C++ ICoreWebView2ScriptDialogOpeningEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptDialogOpeningEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2scriptexception.md
+++ b/1-0-2415-prerelease/icorewebview2scriptexception.md
@@ -1,7 +1,7 @@
 ---
 description: This interface represents a JavaScript exception.
 title: WebView2 Win32 C++ ICoreWebView2ScriptException
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ScriptException
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2servercertificateerrordetectedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2servercertificateerrordetectedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2servercertificateerrordetectedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2servercertificateerrordetectedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: An event handler for the `ServerCertificateErrorDetected` event.
 title: WebView2 Win32 C++ ICoreWebView2ServerCertificateErrorDetectedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ServerCertificateErrorDetectedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2setpermissionstatecompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2setpermissionstatecompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to handle the result of `SetPermissionState`.
 title: WebView2 Win32 C++ ICoreWebView2SetPermissionStateCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SetPermissionStateCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings.md
+++ b/1-0-2415-prerelease/icorewebview2settings.md
@@ -1,7 +1,7 @@
 ---
 description: Defines properties that enable, disable, or modify WebView features.
 title: WebView2 Win32 C++ ICoreWebView2Settings
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings2.md
+++ b/1-0-2415-prerelease/icorewebview2settings2.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages the user agent.
 title: WebView2 Win32 C++ ICoreWebView2Settings2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings3.md
+++ b/1-0-2415-prerelease/icorewebview2settings3.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface that manages whether browser accelerator keys are enabled.
 title: WebView2 Win32 C++ ICoreWebView2Settings3
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings3
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings4.md
+++ b/1-0-2415-prerelease/icorewebview2settings4.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage autofill.
 title: WebView2 Win32 C++ ICoreWebView2Settings4
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings4
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings5.md
+++ b/1-0-2415-prerelease/icorewebview2settings5.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage pinch zoom.
 title: WebView2 Win32 C++ ICoreWebView2Settings5
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings5
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings6.md
+++ b/1-0-2415-prerelease/icorewebview2settings6.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage swipe navigation.
 title: WebView2 Win32 C++ ICoreWebView2Settings6
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings6
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings7.md
+++ b/1-0-2415-prerelease/icorewebview2settings7.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to hide Pdf toolbar items.
 title: WebView2 Win32 C++ ICoreWebView2Settings7
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings7
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings8.md
+++ b/1-0-2415-prerelease/icorewebview2settings8.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage smartscreen.
 title: WebView2 Win32 C++ ICoreWebView2Settings8
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings8
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2settings9.md
+++ b/1-0-2415-prerelease/icorewebview2settings9.md
@@ -1,7 +1,7 @@
 ---
 description: A continuation of the ICoreWebView2Settings interface to manage non-client regions.
 title: WebView2 Win32 C++ ICoreWebView2Settings9
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2Settings9
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2sharedbuffer.md
+++ b/1-0-2415-prerelease/icorewebview2sharedbuffer.md
@@ -1,7 +1,7 @@
 ---
 description: The shared buffer object that is created by CreateSharedBuffer.
 title: WebView2 Win32 C++ ICoreWebView2SharedBuffer
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SharedBuffer
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2sourcechangedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2sourcechangedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `SourceChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2sourcechangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2sourcechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `SourceChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2SourceChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2SourceChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2statechangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2statechangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `StateChanged` event.
 title: WebView2 Win32 C++ ICoreWebView2StateChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StateChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2statusbartextchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2statusbartextchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `StatusBarTextChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2StatusBarTextChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StatusBarTextChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2stringcollection.md
+++ b/1-0-2415-prerelease/icorewebview2stringcollection.md
@@ -1,7 +1,7 @@
 ---
 description: A collection of strings.
 title: WebView2 Win32 C++ ICoreWebView2StringCollection
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2StringCollection
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2trysuspendcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2trysuspendcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: The caller implements this interface to receive the TrySuspend result.
 title: WebView2 Win32 C++ ICoreWebView2TrySuspendCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2TrySuspendCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webmessagereceivedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2webmessagereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebMessageReceived` event.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webmessagereceivedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2webmessagereceivedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Extension of WebMessageReceivedEventArgs to provide access to additional WebMessage objects.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webmessagereceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2webmessagereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebMessageReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebMessageReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebMessageReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourcerequest.md
+++ b/1-0-2415-prerelease/icorewebview2webresourcerequest.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP request used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequest
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequest
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourcerequestedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2webresourcerequestedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourcerequestedeventargs2.md
+++ b/1-0-2415-prerelease/icorewebview2webresourcerequestedeventargs2.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventArgs2
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventArgs2
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourcerequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2webresourcerequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Runs when a URL request (through network, file, and so on) is made in the webview for a Web resource matching resource context filter and URL specified in `AddWebResourceRequestedFilter`.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourceresponse.md
+++ b/1-0-2415-prerelease/icorewebview2webresourceresponse.md
@@ -1,7 +1,7 @@
 ---
 description: An HTTP response used with the `WebResourceRequested` event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponse
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponse
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourceresponsereceivedeventargs.md
+++ b/1-0-2415-prerelease/icorewebview2webresourceresponsereceivedeventargs.md
@@ -1,7 +1,7 @@
 ---
 description: Event args for the WebResourceResponseReceived event.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventArgs
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventArgs
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourceresponsereceivedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2webresourceresponsereceivedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WebResourceResponseReceived` events.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseReceivedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseReceivedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourceresponseview.md
+++ b/1-0-2415-prerelease/icorewebview2webresourceresponseview.md
@@ -1,7 +1,7 @@
 ---
 description: View of the HTTP representation for a web resource response.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseView
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseView
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
+++ b/1-0-2415-prerelease/icorewebview2webresourceresponseviewgetcontentcompletedhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives the result of the ICoreWebView2WebResourceResponseView::GetContent method.
 title: WebView2 Win32 C++ ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WebResourceResponseViewGetContentCompletedHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2windowcloserequestedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2windowcloserequestedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Receives `WindowCloseRequested` events.
 title: WebView2 Win32 C++ ICoreWebView2WindowCloseRequestedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowCloseRequestedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2windowfeatures.md
+++ b/1-0-2415-prerelease/icorewebview2windowfeatures.md
@@ -1,7 +1,7 @@
 ---
 description: The window features for a WebView popup window.
 title: WebView2 Win32 C++ ICoreWebView2WindowFeatures
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2WindowFeatures
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/icorewebview2zoomfactorchangedeventhandler.md
+++ b/1-0-2415-prerelease/icorewebview2zoomfactorchangedeventhandler.md
@@ -1,7 +1,7 @@
 ---
 description: Implements the interface to receive `ZoomFactorChanged` events.
 title: WebView2 Win32 C++ ICoreWebView2ZoomFactorChangedEventHandler
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html, ICoreWebView2ZoomFactorChangedEventHandler
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/index.md
+++ b/1-0-2415-prerelease/index.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 C++ Reference
 title: WebView2 Win32 C++ Reference
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 ---
 

--- a/1-0-2415-prerelease/webview2-idl.md
+++ b/1-0-2415-prerelease/webview2-idl.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 Globals
 title: Globals
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 topic_type: 
 - APIRef

--- a/1-0-2415-prerelease/webview2experimental-idl.md
+++ b/1-0-2415-prerelease/webview2experimental-idl.md
@@ -1,7 +1,7 @@
 ---
 description: WebView2 Win32 Experimental Globals
 title: Experimental Globals
-ms.date: 02/26/2023
+ms.date: 02/26/2024
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Controller, browser control, edge html
 topic_type: 
 - APIRef


### PR DESCRIPTION
https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2launchingexternalurischemeeventargs?view=webview2-1.0.2415-prerelease&branch=pr-en-us-85#get_initiatingorigin